### PR TITLE
feat: Add ft_lstinsert_after to libft

### DIFF
--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/16 13:33:38 by ldulling          #+#    #+#              #
-#    Updated: 2023/12/07 03:12:53 by ldulling         ###   ########.fr        #
+#    Updated: 2023/12/16 23:54:21 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -50,6 +50,7 @@ TMP		+=	$(addprefix $(DIR)$(SUBDIR), \
 			ft_lstadd_front.c \
 			ft_lstclear.c \
 			ft_lstdelone.c \
+			ft_lstinsert_after.c \
 			ft_lstiter.c \
 			ft_lstlast.c \
 			ft_lstmap.c \

--- a/libraries/libft/inc/libft.h
+++ b/libraries/libft/inc/libft.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/24 16:17:46 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/09 13:33:08 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/16 23:53:50 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,6 +49,7 @@ void		ft_lstadd_back(t_list **lst, t_list *new);
 void		ft_lstadd_front(t_list **lst, t_list *new);
 void		ft_lstclear(t_list **lst, void (*del)(void *));
 void		ft_lstdelone(t_list *lst, void (*del)(void *));
+void		ft_lstinsert_after(t_list **lst, t_list *new);
 void		ft_lstiter(t_list *lst, void (*f)(void *));
 t_list		*ft_lstlast(t_list *lst);
 t_list		*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *));

--- a/libraries/libft/src/libft/lists/singly_linked/ft_lstinsert_after.c
+++ b/libraries/libft/src/libft/lists/singly_linked/ft_lstinsert_after.c
@@ -1,0 +1,45 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_lstinsert_after.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/09/24 16:04:12 by ldulling          #+#    #+#             */
+/*   Updated: 2023/12/16 23:49:45 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+/**
+ * The ft_lstinsert_after function inserts a new node after a given node in a
+ * singly linked list.
+ *
+ * @param lst   A double pointer to the node after which the new node should be
+ *              inserted.
+ *              If *lst is NULL, the new node is set as the first node.
+ * @param new   The new node to be inserted into the list.
+ */
+
+#include "libft.h"
+
+void	ft_lstinsert_after(t_list **lst, t_list *new)
+{
+	t_list	*last_new;
+	t_list	*old;
+
+	if (lst != NULL && new != NULL)
+	{
+		if (*lst == NULL)
+			*lst = new;
+		else
+		{
+			old = *lst->next;
+			*lst->next = new;
+			last_new = new;
+			while (last_new->next != NULL)
+				last_new = last_new->next;
+			last_new->next = old;
+		}
+	}
+	return ;
+}


### PR DESCRIPTION
The ft_lstinsert_after function inserts a new node after a given node in a singly linked list.
It will be very useful in the lexer.