### PR TITLE
[FEAT]: Add ft_split_at_index to libft

### DIFF
--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/16 13:33:38 by ldulling          #+#    #+#              #
-#    Updated: 2023/12/16 23:54:21 by ldulling         ###   ########.fr        #
+#    Updated: 2023/12/17 14:25:35 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -107,6 +107,7 @@ SUBDIR	:=	strings/
 TMP		+=	$(addprefix $(DIR)$(SUBDIR), \
 			ft_itoa.c \
 			ft_split.c \
+			ft_split_at_index.c \
 			ft_strchr.c \
 			ft_strcmp.c \
 			ft_strdup.c \

--- a/libraries/libft/inc/libft.h
+++ b/libraries/libft/inc/libft.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/24 16:17:46 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/16 23:53:50 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/17 14:25:15 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,6 +91,7 @@ void		ft_putstr_fd(char *s, int fd);
 /* Strings */
 char		*ft_itoa(int n);
 char		**ft_split(char const *s, char c);
+char		**ft_split_at_index(char *str, size_t index);
 char		*ft_strchr(const char *s, int c);
 int			ft_strcmp(const char *s1, const char *s2);
 char		*ft_strdup(const char *s);

--- a/libraries/libft/src/libft/strings/ft_split_at_index.c
+++ b/libraries/libft/src/libft/strings/ft_split_at_index.c
@@ -6,33 +6,51 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/17 12:00:03 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/17 12:07:55 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/17 14:36:54 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+/**
+ * The ft_split_at_index function splits a string at a given index into two
+ * parts.
+ *
+ * @param str   The string to be split.
+ * @param index The position at which to split the string.
+ *
+ * @return On success, it returns a pointer to an array of two strings:
+ *         The first string is the part before the index, and the second string
+ *         is the part from the index to the end of the original string.
+ *         If the input string is NULL, the index is out of bounds, or memory
+ *         allocation fails, it returns NULL.
+ */
+
 #include "libft.h"
 
-char	*ft_split_at_index(char **str, size_t index)
+char	**ft_split_at_index(char *str, size_t index)
 {
 	size_t	len;
-	char	*part1;
-	char	*part2;
+	char	**str_array;
 
-	if (!str || !*str)
+	if (!str)
 		return (NULL);
-	len = ft_strlen(*str);
+	len = ft_strlen(str);
 	if (index > len)
 		return (NULL);
-	part1 = ft_substr(*str, 0, index);
-	if (!part1)
+	str_array = (char **) malloc(2 * sizeof(char *));
+	if (!str_array)
 		return (NULL);
-	part2 = ft_substr(*str, index, len);
-	if (!part2)
+	str_array[0] = ft_substr(str, 0, index);
+	if (!str_array[0])
 	{
-		free(part1);
+		free(str_array);
 		return (NULL);
 	}
-	free(*str);
-	*str = part1;
-	return (part2);
+	str_array[1] = ft_substr(str, index, len);
+	if (!str_array[1])
+	{
+		free(str_array[0]);
+		free(str_array);
+		return (NULL);
+	}
+	return (str_array);
 }


### PR DESCRIPTION
```
/**
 * The ft_split_at_index function splits a string at a given index into two
 * parts.
 *
 * @param str   The string to be split.
 * @param index The position at which to split the string.
 *
 * @return On success, it returns a pointer to an array of two strings:
 *         The first string is the part before the index, and the second string
 *         is the part from the index to the end of the original string.
 *         If the input string is NULL, the index is out of bounds, or memory
 *         allocation fails, it returns NULL.
 */
```