### PR TITLE
[FEAT] Add ft_lstpop_content to libft

### DIFF
--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/16 13:33:38 by ldulling          #+#    #+#              #
-#    Updated: 2023/12/19 20:05:30 by ldulling         ###   ########.fr        #
+#    Updated: 2023/12/19 20:42:02 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -56,6 +56,7 @@ TMP		+=	$(addprefix $(DIR)$(SUBDIR), \
 			ft_lstmap.c \
 			ft_lstnew.c \
 			ft_lstpop.c \
+			ft_lstpop_content.c \
 			ft_lstsize.c \
 			ft_lstsort_bubble.c \
 )

--- a/libraries/libft/inc/libft.h
+++ b/libraries/libft/inc/libft.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/24 16:17:46 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/19 20:05:16 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/19 20:40:59 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,7 @@ t_list		*ft_lstlast(t_list *lst);
 t_list		*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *));
 t_list		*ft_lstnew(void *content);
 t_list		*ft_lstpop(t_list **lst);
+void		*ft_lstpop_content(t_list **lst);
 int			ft_lstsize(t_list *lst);
 void		ft_lstsort_bubble(t_list **lst, void *(*cmp)(void *, void *));
 

--- a/libraries/libft/src/libft/lists/singly_linked/ft_lstpop_content.c
+++ b/libraries/libft/src/libft/lists/singly_linked/ft_lstpop_content.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_lstpop_content.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/09/24 16:04:29 by ldulling          #+#    #+#             */
+/*   Updated: 2023/12/19 20:40:38 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+/**
+ * The ft_lstpop_content function removes and frees the first node from a singly
+ * linked list and returns its content - like popping a stack.
+ *
+ * @param lst   A double pointer to the first node of the list.
+ *
+ * @return      The content of the removed node, or NULL if the list was empty.
+ */
+
+#include "libft.h"
+
+void	*ft_lstpop_content(t_list **lst)
+{
+	void	*popped_content;
+	t_list	*popped_node;
+
+	if (lst == NULL || *lst == NULL)
+		return (NULL);
+	popped_node = *lst;
+	popped_content = popped_node->content;
+	*lst = (*lst)->next;
+	free(popped_node);
+	return (popped_content);
+}


### PR DESCRIPTION
```
/**
 * The ft_lstpop_content function removes and frees the first node from a singly
 * linked list and returns its content - like popping a stack.
 *
 * @param lst   A double pointer to the first node of the list.
 *
 * @return      The content of the removed node, or NULL if the list was empty.
 */
```