### PR TITLE
[FIX] Set T_ASSIGNMENT_WORD token types correctly in lexer

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 10:35:51 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 18:01:27 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 19:45:33 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,10 @@
 bool	create_token_list(t_list **token_list, t_list **token_data_list);
 bool	separate_operators(t_list *lst_node, size_t i);
 bool	add_end_node(t_list	**token_list);
+
+/* finetune_token_list.c */
+void	finetune_token_list(t_list *token_list);
+void	adjust_assignment_word_tokens(t_list *token_list);
 
 /* get_token_data_list.c */
 t_list	*get_token_data_list(char *input_line);

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 10:35:51 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 12:06:05 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/20 18:01:27 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,27 +16,27 @@
 # include "defines.h"
 
 /* create_token_list.c */
-bool	create_token_list(t_list **token_list, t_list **data_list);
+bool	create_token_list(t_list **token_list, t_list **token_data_list);
 bool	separate_operators(t_list *lst_node, size_t i);
 bool	add_end_node(t_list	**token_list);
 
-/* get_data.c */
-bool	get_data_list(t_list **data_list, char *input_line);
-char	*get_data(char *input_line, size_t *i);
-
-/* get_type.c */
-void	get_type(t_list *lst_node);
-int		which_lesser(char *data);
-int		which_greater(char *data);
-int		which_pipe(char *data);
-bool	is_assignment_word(char *str);
+/* get_token_data_list.c */
+t_list	*get_token_data_list(char *input_line);
+char	*get_token_data(char *input_line, size_t *i);
 
 /* lexer.c */
 bool	ft_lexer(t_shell *shell);
 
 /* lexer_utils.c */
-void	skip_operator(char *data, size_t *i);
+void	skip_operator(char *token_data, size_t *i);
 void	skip_past_same_quote(char *str, size_t *i);
 bool	split_node(t_list *lst_node1, size_t i);
+
+/* set_token_type.c */
+void	set_token_type(t_list *lst_node);
+int		which_lesser(char *token_data);
+int		which_greater(char *token_data);
+int		which_pipe(char *token_data);
+bool	is_assignment_word(char *str);
 
 #endif

--- a/source/frontend/lexer/create_token_list.c
+++ b/source/frontend/lexer/create_token_list.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 11:54:32 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 18:09:34 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 20:09:21 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ bool	create_token_list(t_list **token_list, t_list **token_data_list)
 	}
 	if (*token_data_list)
 		return (ft_lstclear(token_data_list, free), free_token_node(token), \
-				ft_lstclear(&new_nodes, free), false);
+				ft_lstclear(&new_nodes, free_token_node), false);
 	return (true);
 }
 
@@ -41,7 +41,7 @@ bool	separate_operators(t_list *lst_node, size_t i)
 {
 	char	*token_data;
 
-	token_data = ((t_token *) lst_node->content)->data;
+	token_data = get_token_data_from_list(lst_node);
 	while (token_data[i])
 	{
 		if (ft_strchr(TOK_SYMBOLS, token_data[i]))
@@ -53,7 +53,7 @@ bool	separate_operators(t_list *lst_node, size_t i)
 				if (!split_node(lst_node, i))
 					return (false);
 				lst_node = lst_node->next;
-				token_data = ((t_token *) lst_node->content)->data;
+				token_data = get_token_data_from_list(lst_node);
 				i = 0;
 			}
 		}
@@ -75,7 +75,7 @@ bool	add_end_node(t_list	**token_list)
 		return (false);
 	new_node = (ft_lstnew(token));
 	if (!new_node)
-		return (free(token), false);
+		return (free_token_node(token), false);
 	ft_lstadd_back(token_list, new_node);
 	return (true);
 }

--- a/source/frontend/lexer/create_token_list.c
+++ b/source/frontend/lexer/create_token_list.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 11:54:32 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 12:05:34 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/20 18:02:10 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,52 +14,52 @@
 #include "minishell.h"
 #include "utils.h"
 
-bool	create_token_list(t_list **token_list, t_list **data_list)
+bool	create_token_list(t_list **token_list, t_list **token_data_list)
 {
 	t_list	*new_nodes;
 	t_token	*token;
 
 	new_nodes = NULL;
-	while (*data_list)
+	while (*token_data_list)
 	{
-		token = init_token_node(T_UNINITIALIZED, (*data_list)->content);
+		token = init_token_node(T_UNINITIALIZED, (*token_data_list)->content);
 		if (!token)
 			break ;
 		new_nodes = ft_lstnew(token);
 		if (!new_nodes || !separate_operators(new_nodes, 0))
 			break ;
-		get_type(new_nodes);
+		set_token_type(shell->token_list);
 		ft_lstadd_back(token_list, new_nodes);
-		free(ft_lstpop(data_list));
+		free(ft_lstpop(token_data_list));
 	}
-	if (*data_list)
-		return (ft_lstclear(data_list, free), free_token_node(token), \
+	if (*token_data_list)
+		return (ft_lstclear(token_data_list, free), free_token_node(token), \
 				ft_lstclear(&new_nodes, free), false);
 	return (true);
 }
 
 bool	separate_operators(t_list *lst_node, size_t i)
 {
-	char	*data;
+	char	*token_data;
 
-	data = ((t_token *) lst_node->content)->data;
-	while (data[i])
+	token_data = ((t_token *) lst_node->content)->data;
+	while (token_data[i])
 	{
-		if (ft_strchr(TOK_SYMBOLS, data[i]))
+		if (ft_strchr(TOK_SYMBOLS, token_data[i]))
 		{
 			if (i == 0)
-				skip_operator(data, &i);
-			if (data[i])
+				skip_operator(token_data, &i);
+			if (token_data[i])
 			{
 				if (!split_node(lst_node, i))
 					return (false);
 				lst_node = lst_node->next;
-				data = ((t_token *) lst_node->content)->data;
+				token_data = ((t_token *) lst_node->content)->data;
 				i = 0;
 			}
 		}
-		else if (ft_strchr(QUOTES, data[i]))
-			skip_past_same_quote(data, &i);
+		else if (ft_strchr(QUOTES, token_data[i]))
+			skip_past_same_quote(token_data, &i);
 		else
 			i++;
 	}

--- a/source/frontend/lexer/create_token_list.c
+++ b/source/frontend/lexer/create_token_list.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 11:54:32 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 18:02:10 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/20 18:09:34 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,6 @@ bool	create_token_list(t_list **token_list, t_list **token_data_list)
 		new_nodes = ft_lstnew(token);
 		if (!new_nodes || !separate_operators(new_nodes, 0))
 			break ;
-		set_token_type(shell->token_list);
 		ft_lstadd_back(token_list, new_nodes);
 		free(ft_lstpop(token_data_list));
 	}

--- a/source/frontend/lexer/create_token_list.c
+++ b/source/frontend/lexer/create_token_list.c
@@ -11,7 +11,6 @@
 /* ************************************************************************** */
 
 #include "lexer.h"
-#include "minishell.h"
 #include "utils.h"
 
 bool	create_token_list(t_list **token_list, t_list **token_data_list)

--- a/source/frontend/lexer/finetune_token_list.c
+++ b/source/frontend/lexer/finetune_token_list.c
@@ -1,0 +1,43 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   finetune_token_list.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/12/21 19:37:15 by ldulling          #+#    #+#             */
+/*   Updated: 2023/12/21 19:44:04 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "lexer.h"
+
+void	finetune_token_list(t_list *token_list)
+{
+	if (!token_list)
+		return ;
+	adjust_assignment_word_tokens(token_list);
+}
+
+void	adjust_assignment_word_tokens(t_list *token_list)
+{
+	int		prev_type;
+	t_token	*token;
+
+	prev_type = T_UNINITIALIZED;
+	while (token_list)
+	{
+		token = (t_token *) token_list->content;
+		if (token->type == T_ASSIGNMENT_WORD)
+		{
+			if (prev_type != T_UNINITIALIZED && prev_type != T_ASSIGNMENT_WORD
+				&& prev_type != T_PIPE && prev_type != T_OR
+				&& prev_type != T_AND && prev_type != T_L_BRACKET)
+			{
+				token->type = T_WORD;
+			}
+		}
+		prev_type = token->type;
+		token_list = token_list->next;
+	}
+}

--- a/source/frontend/lexer/get_token_data_list.c
+++ b/source/frontend/lexer/get_token_data_list.c
@@ -6,12 +6,11 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 11:30:35 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/21 17:09:45 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 20:28:46 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lexer.h"
-#include "minishell.h"
 
 t_list	*get_token_data_list(char *input_line)
 {
@@ -33,7 +32,8 @@ t_list	*get_token_data_list(char *input_line)
 			return (ft_lstclear(&token_data_list, free), NULL);
 		new_node = ft_lstnew(token_data);
 		if (!new_node)
-			return (ft_lstclear(&token_data_list, free), free(token_data), NULL);
+			return (ft_lstclear(&token_data_list, free), free(token_data),
+				NULL);
 		ft_lstadd_back(&token_data_list, new_node);
 	}
 	return (token_data_list);

--- a/source/frontend/lexer/get_token_data_list.c
+++ b/source/frontend/lexer/get_token_data_list.c
@@ -1,24 +1,26 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   get_data.c                                         :+:      :+:    :+:   */
+/*   get_token_data_list.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 11:30:35 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 12:11:56 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 17:09:45 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lexer.h"
 #include "minishell.h"
 
-bool	get_data_list(t_list **data_list, char *input_line)
+t_list	*get_token_data_list(char *input_line)
 {
-	char	*data;
-	t_list	*new_node;
 	size_t	i;
+	t_list	*new_node;
+	char	*token_data;
+	t_list	*token_data_list;
 
+	token_data_list = NULL;
 	i = 0;
 	while (input_line[i])
 	{
@@ -26,18 +28,18 @@ bool	get_data_list(t_list **data_list, char *input_line)
 			i++;
 		if (!input_line[i])
 			break ;
-		data = get_data(input_line, &i);
-		if (!data)
-			return (ft_lstclear(data_list, free), false);
-		new_node = ft_lstnew(data);
+		token_data = get_token_data(input_line, &i);
+		if (!token_data)
+			return (ft_lstclear(&token_data_list, free), NULL);
+		new_node = ft_lstnew(token_data);
 		if (!new_node)
-			return (ft_lstclear(data_list, free), free(data), false);
-		ft_lstadd_back(data_list, new_node);
+			return (ft_lstclear(&token_data_list, free), free(token_data), NULL);
+		ft_lstadd_back(&token_data_list, new_node);
 	}
-	return (true);
+	return (token_data_list);
 }
 
-char	*get_data(char *input_line, size_t *i)
+char	*get_token_data(char *input_line, size_t *i)
 {
 	size_t	start;
 

--- a/source/frontend/lexer/lexer.c
+++ b/source/frontend/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 08:31:35 by codespace         #+#    #+#             */
-/*   Updated: 2023/12/21 20:09:35 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 21:05:23 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ bool	ft_lexer(t_shell *shell)
 	t_list	*token_data_list;
 
 	if (!shell || !shell->input_line)
-		return (NULL);
+		return (false);
 	token_data_list = get_token_data_list(shell->input_line);
 	if (!token_data_list)
 		return (false);

--- a/source/frontend/lexer/lexer.c
+++ b/source/frontend/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 08:31:35 by codespace         #+#    #+#             */
-/*   Updated: 2023/12/20 12:06:41 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 17:01:42 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,20 +24,22 @@ NOTES:
 	[x] a"b"c=456 -> WORD (unspecified)
 	[ ] export >a=def -> a=def will be a WORD?
 		! Need to test with parser what will happen here
+
+	parser branch has useful token functions in utils - USE THEM! (after parser-branch merged)
 */
 
 /* < > << >> | || && ( ) */
 
 bool	ft_lexer(t_shell *shell)
 {
-	t_list	*data_list;
+	t_list	*token_data_list;
 
 	if (!shell || !shell->input_line)
 		return (NULL);
-	data_list = NULL;
-	if (!get_data_list(&data_list, shell->input_line))
+	token_data_list = get_token_data_list(shell->input_line);
+	if (!token_data_list)
 		return (false);
-	if (!create_token_list(&shell->token_list, &data_list))
+	if (!create_token_list(&shell->token_list, &token_data_list))
 		return (false);
 	if (!add_end_node(&shell->token_list))
 		return (false);

--- a/source/frontend/lexer/lexer.c
+++ b/source/frontend/lexer/lexer.c
@@ -6,28 +6,11 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 08:31:35 by codespace         #+#    #+#             */
-/*   Updated: 2023/12/21 19:46:04 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 20:09:35 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lexer.h"
-#include "minishell.h"
-#include "utils.h"
-
-/*
-NOTES:
-- END token at the end
-- echo>out should be split into 3 tokens
-- Assignment word!
-	[x] =abc -> WORD
-	[x] abc=abc -> ASSIGNMENT_WORD
-	[x] a"b"c=456 -> WORD (unspecified)
-	[x] export >a=def -> a=def will be a WORD?
-
-	parser branch has useful token functions in utils - USE THEM! (after parser-branch merged)
-*/
-
-/* < > << >> | || && ( ) */
 
 bool	ft_lexer(t_shell *shell)
 {

--- a/source/frontend/lexer/lexer.c
+++ b/source/frontend/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 08:31:35 by codespace         #+#    #+#             */
-/*   Updated: 2023/12/21 17:03:15 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 19:46:04 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,8 +22,7 @@ NOTES:
 	[x] =abc -> WORD
 	[x] abc=abc -> ASSIGNMENT_WORD
 	[x] a"b"c=456 -> WORD (unspecified)
-	[ ] export >a=def -> a=def will be a WORD?
-		! Need to test with parser what will happen here
+	[x] export >a=def -> a=def will be a WORD?
 
 	parser branch has useful token functions in utils - USE THEM! (after parser-branch merged)
 */
@@ -42,6 +41,7 @@ bool	ft_lexer(t_shell *shell)
 	if (!create_token_list(&shell->token_list, &token_data_list))
 		return (false);
 	set_token_type(shell->token_list);
+	finetune_token_list(shell->token_list);
 	if (!add_end_node(&shell->token_list))
 		return (false);
 	return (true);

--- a/source/frontend/lexer/lexer.c
+++ b/source/frontend/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 08:31:35 by codespace         #+#    #+#             */
-/*   Updated: 2023/12/21 17:01:42 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 17:03:15 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,7 @@ bool	ft_lexer(t_shell *shell)
 		return (false);
 	if (!create_token_list(&shell->token_list, &token_data_list))
 		return (false);
+	set_token_type(shell->token_list);
 	if (!add_end_node(&shell->token_list))
 		return (false);
 	return (true);

--- a/source/frontend/lexer/lexer_utils.c
+++ b/source/frontend/lexer/lexer_utils.c
@@ -6,23 +6,23 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 10:33:59 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 11:34:52 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/20 17:59:25 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 #include "utils.h"
 
-void	skip_operator(char *data, size_t *i)
+void	skip_operator(char *token_data, size_t *i)
 {
-	if (data[*i] == '<' || data[*i] == '>' || \
-		data[*i] == '|' || data[*i] == '&')
+	if (token_data[*i] == '<' || token_data[*i] == '>' || \
+		token_data[*i] == '|' || token_data[*i] == '&')
 	{
 		(*i)++;
-		if (data[*i] == data[*i - 1])
+		if (token_data[*i] == token_data[*i - 1])
 			(*i)++;
 	}
-	else if (data[*i] == '(' || data[*i] == ')')
+	else if (token_data[*i] == '(' || token_data[*i] == ')')
 		(*i)++;
 }
 
@@ -47,24 +47,24 @@ void	skip_past_same_quote(char *str, size_t *i)
 
 bool	split_node(t_list *lst_node1, size_t i)
 {
-	char	**data_node1;
-	char	**data_split;
 	t_list	*lst_node2;
 	t_token	*new_token;
+	char	**token_data_node1;
+	char	**token_data_split;
 
-	data_node1 = &((t_token *) lst_node1->content)->data;
-	data_split = ft_split_at_index(*data_node1, i);
-	if (!data_split)
+	token_data_node1 = &((t_token *) lst_node1->content)->data;
+	token_data_split = ft_split_at_index(*token_data_node1, i);
+	if (!token_data_split)
 		return (false);
-	free(*data_node1);
-	*data_node1 = data_split[0];
-	new_token = init_token_node(T_UNINITIALIZED, data_split[1]);
+	free(*token_data_node1);
+	*token_data_node1 = token_data_split[0];
+	new_token = init_token_node(T_UNINITIALIZED, token_data_split[1]);
 	if (!new_token)
-		return (free(data_split[1]), free(data_split), false);
+		return (free(token_data_split[1]), free(token_data_split), false);
 	lst_node2 = ft_lstnew(new_token);
 	if (!lst_node2)
-		return (free_token_node(new_token), free(data_split), (false));
+		return (free_token_node(new_token), free(token_data_split), (false));
 	ft_lstinsert_after(&lst_node1, lst_node2);
-	free(data_split);
+	free(token_data_split);
 	return (true);
 }

--- a/source/frontend/lexer/lexer_utils.c
+++ b/source/frontend/lexer/lexer_utils.c
@@ -6,11 +6,10 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 10:33:59 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 17:59:25 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 20:15:55 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
 #include "utils.h"
 
 void	skip_operator(char *token_data, size_t *i)

--- a/source/frontend/lexer/set_token_type.c
+++ b/source/frontend/lexer/set_token_type.c
@@ -1,40 +1,40 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   get_type.c                                      :+:      :+:    :+:   */
+/*   set_token_type.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/12/20 10:28:00 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/20 10:53:19 by ldulling         ###   ########.fr       */
+/*   Created: 2023/12/21 16:20:32 by ldulling          #+#    #+#             */
+/*   Updated: 2023/12/21 16:20:36 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 #include "lexer.h"
 
-void	get_type(t_list *lst_node)
+void	set_token_type(t_list *lst_node)
 {
-	char	*data;
 	t_token	*token;
+	char	*token_data;
 
 	while (lst_node)
 	{
 		token = (t_token *) lst_node->content;
-		data = token->data;
-		if (*data == '<')
-			token->type = which_lesser(data);
-		else if (*data == '>')
-			token->type = which_greater(data);
-		else if (*data == '|')
-			token->type = which_pipe(data);
-		else if (ft_strcmp("&&", data) == 0)
+		token_data = token->data;
+		if (*token_data == '<')
+			token->type = which_lesser(token_data);
+		else if (*token_data == '>')
+			token->type = which_greater(token_data);
+		else if (*token_data == '|')
+			token->type = which_pipe(token_data);
+		else if (ft_strcmp("&&", token_data) == 0)
 			token->type = T_AND;
-		else if (*data == '(')
+		else if (*token_data == '(')
 			token->type = T_L_BRACKET;
-		else if (*data == ')')
+		else if (*token_data == ')')
 			token->type = T_R_BRACKET;
-		else if (is_assignment_word(data))
+		else if (is_assignment_word(token_data))
 			token->type = T_ASSIGNMENT_WORD;
 		else
 			token->type = T_WORD;
@@ -42,25 +42,25 @@ void	get_type(t_list *lst_node)
 	}
 }
 
-int	which_lesser(char *data)
+int	which_lesser(char *token_data)
 {
-	if (ft_strcmp("<<", data) == 0)
+	if (ft_strcmp("<<", token_data) == 0)
 		return (T_HERE_DOC);
 	else
 		return (T_RED_IN);
 }
 
-int	which_greater(char *data)
+int	which_greater(char *token_data)
 {
-	if (ft_strcmp(">>", data) == 0)
+	if (ft_strcmp(">>", token_data) == 0)
 		return (T_APPEND);
 	else
 		return (T_RED_OUT);
 }
 
-int	which_pipe(char *data)
+int	which_pipe(char *token_data)
 {
-	if (ft_strcmp("||", data) == 0)
+	if (ft_strcmp("||", token_data) == 0)
 		return (T_OR);
 	else
 		return (T_PIPE);

--- a/source/frontend/lexer/set_token_type.c
+++ b/source/frontend/lexer/set_token_type.c
@@ -6,11 +6,10 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/21 16:20:32 by ldulling          #+#    #+#             */
-/*   Updated: 2023/12/21 16:20:36 by ldulling         ###   ########.fr       */
+/*   Updated: 2023/12/21 20:16:16 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
 #include "lexer.h"
 
 void	set_token_type(t_list *lst_node)


### PR DESCRIPTION
Included are the following enhancements to the lexer:
1. Rename variable and function names to make it more clear when they are connected to tokens.

2. Set the token type now after the token_list has been fully created. Previously the lexer always switched back and forth between creating more token_list nodes and assigning the token_type.

3. Fix potential memory leaks from not always clearing the token data if any malloc during the lexer fails.

4. Only include the header files in each source file that are necessary.

resolves #19
resolves #21 