### PR TITLE
[BUILD] Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,18 @@ INCLUDES 	:= -I./include -I./libraries/libft/inc
 LIBFT 		:= ./libraries/libft
 LIBFT_LIB 	:= libft.a
 
+B			:= build/
+O			:= $B_obj/
+
 CC 			:= cc
 CFLAGS 		:= -Wall -Wextra -Werror -g
 MAKEFLAGS	:= -j$(nproc)
 
 # TODO: need to remove forbidden wildcard
-SRC 		= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
-OBJ 		= $(SRC:.c=.o)
+SRC 		:= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
+OBJ 		:= $(SRC:%.c=$O%.o)
+
+SUBDIRS_O	:= $(sort $(dir $(OBJ)))
 
 all:		$(NAME)
 
@@ -17,12 +22,16 @@ $(NAME):	$(OBJ)
 		$(MAKE) -C $(LIBFT)
 		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) -L$(LIBFT) -lft -lreadline -o $(NAME)
 
-%.o: %.c
+$O%.o:		%.c | $(SUBDIRS_O)
 		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+
+$(SUBDIRS_O):
+		mkdir -p $@
 
 clean:
 		$(MAKE) -C $(LIBFT) clean
 		rm -f $(OBJ)
+		-find $O -type d -empty -delete
 
 fclean: 	clean
 		$(MAKE) -C $(LIBFT) fclean

--- a/Makefile
+++ b/Makefile
@@ -1,77 +1,143 @@
-NAME 		:= minishell
+# **************************************************************************** #
+#                                                                              #
+#                                                         :::      ::::::::    #
+#    Makefile                                           :+:      :+:    :+:    #
+#                                                     +:+ +:+         +:+      #
+#    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
+#                                                 +#+#+#+#+#+   +#+            #
+#    Created: 2023/12/23 03:22:46 by ldulling          #+#    #+#              #
+#    Updated: 2023/12/23 03:53:23 by ldulling         ###   ########.fr        #
+#                                                                              #
+# **************************************************************************** #
 
-BUILD_DIR	:= build
-OBJ_DIR		:= $(BUILD_DIR)/_obj
-DEP_DIR		:= $(BUILD_DIR)/_dep
-LIB_DIR		:= libraries
 
-LIBRARIES		:= $(wildcard $(LIB_DIR)/*)
-LIBRARIES_EXT	:= readline
-INCLUDES 		:= -I./include -I./$(LIBRARIES)/inc
+# ***************************** CONFIGURATION ******************************** #
 
-CC 			:=	cc
-CFLAGS 		:=	-Wall -Wextra -Werror -g
-LIBFLAGS	:=	$(addprefix -L,$(LIBRARIES)) \
-				$(addprefix -l,$(patsubst lib%,%,$(notdir \
-				$(LIBRARIES) $(LIBRARIES_EXT))))
-MAKEFLAGS	:=	-j -s
+#	Executable
+
+NAME 			:=	minishell
+
+
+#	Directories
+
+BUILD_DIR		:=	build
+OBJ_DIR			:=	$(BUILD_DIR)/_obj
+DEP_DIR			:=	$(BUILD_DIR)/_dep
+LIB_DIR			:=	libraries
+
+
+#	Dependencies
+
+LIBRARIES		:=	$(wildcard $(LIB_DIR)/*)
+LIBRARIES_EXT	:=	readline
+INCLUDES 		:=	-I./include -I./$(LIBRARIES)/inc
+
+
+#	Flags
+
+CC 				:=	cc
+CFLAGS 			:=	-Wall -Wextra -Werror -g
+LIBFLAGS		:=	$(addprefix -L,$(LIBRARIES)) \
+					$(addprefix -l,$(patsubst lib%,%,$(notdir \
+					$(LIBRARIES) $(LIBRARIES_EXT))))
+MAKEFLAGS		:=	-j -s
+
+
+#	Files
 
 # TODO: need to remove forbidden wildcard
-SRC 		:= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
-OBJ 		:= $(SRC:%.c=$(OBJ_DIR)/%.o)
-DEP			:= $(SRC:%.c=$(DEP_DIR)/%.d)
+SRC 			:=	$(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
+OBJ 			:=	$(SRC:%.c=$(OBJ_DIR)/%.o)
+DEP				:=	$(SRC:%.c=$(DEP_DIR)/%.d)
 
-OBJ_SUBDIRS	:= $(sort $(dir $(OBJ)))
-DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
 
-export		MAKECMDGOALS
-.PHONY:		all build lib clean fclean re
+#	Subdirectories
 
-all:
-		($(MAKE) --question build && echo -n $(MSG_NO_CHNG)) \
-		|| (echo -n $(MSG_START) && ($(MAKE) build \
-		&& echo -n $(MSG_SUCCESS)) || echo -n $(MSG_FAILURE))
+OBJ_SUBDIRS		:=	$(sort $(dir $(OBJ)))
+DEP_SUBDIRS		:=	$(sort $(dir $(DEP)))
+
+
+# ***************************** BUILD PROCESS ******************************** #
+
+.PHONY			:	all build lib clean fclean re
+
+
+#	Compilation
+
+all				:
+					($(MAKE) --question build && echo -n $(MSG_NO_CHNG)) \
+						|| (echo -n $(MSG_START) \
+							&& ($(MAKE) build && echo -n $(MSG_SUCCESS)) \
+							|| echo -n $(MSG_FAILURE))
+
+
+#		Version check for Make
 
 ifeq ($(firstword $(sort $(MAKE_VERSION) 4.4)),4.4)
-build:		lib .WAIT $(NAME)
+build			:	lib .WAIT $(NAME)
 else
-.NOTPARALLEL:	lib
-build:		lib $(NAME)
+.NOTPARALLEL:		lib
+build			:	lib $(NAME)
 endif
 
-lib:
-		$(MAKE) -C $(LIBRARIES)
 
-$(NAME):	$(LIBRARIES) $(OBJ)
-		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
+#		Library compilation
 
-$(OBJ_DIR)/%.o:		%.c Makefile | $(OBJ_SUBDIRS)
-		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ \
-		&& echo -n $(MSG_PROGRESS)
+export				MAKECMDGOALS
 
-$(DEP_DIR)/%.d:		%.c Makefile | $(DEP_SUBDIRS)
-		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
+lib				:
+					$(MAKE) -C $(LIBRARIES)
 
-$(OBJ_SUBDIRS) $(DEP_SUBDIRS):
-		mkdir -p $@
+
+#		Executable linking
+
+$(NAME)			:	$(LIBRARIES) $(OBJ)
+					$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
+
+
+#		Source file compiling
+
+$(OBJ_DIR)/%.o	:	%.c Makefile | $(OBJ_SUBDIRS)
+					$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ \
+						&& echo -n $(MSG_PROGRESS)
+
+
+#		Pre-processing and dependency file creation
+
+$(DEP_DIR)/%.d	:	%.c Makefile | $(DEP_SUBDIRS)
+					$(CC) $(CFLAGS) $(INCLUDES) \
+						-M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
+
+
+#		Mirror directory structure for build artifacts
+
+$(OBJ_SUBDIRS) \
+$(DEP_SUBDIRS)	:
+					mkdir -p $@
+
+
+#	Cleaning
 
 clean:
-		$(MAKE) -C $(LIBRARIES)
-		rm -f $(OBJ) $(DEP)
+					$(MAKE) -C $(LIBRARIES)
+					rm -f $(OBJ) $(DEP)
 ifneq (,$(wildcard $(OBJ_DIR)))
-		-find $(OBJ_DIR) -type d -empty -delete
+					-find $(OBJ_DIR) -type d -empty -delete
 endif
 ifneq (,$(wildcard $(DEP_DIR)))
-		-find $(DEP_DIR) -type d -empty -delete
+					-find $(DEP_DIR) -type d -empty -delete
 endif
 
-fclean: 	clean
-		$(MAKE) -C $(LIBRARIES)
-		rm -f $(NAME)
+fclean			:	clean
+					$(MAKE) -C $(LIBRARIES)
+					rm -f $(NAME)
 
-re:
-		$(MAKE) fclean
-		$(MAKE) all
+re				:
+					$(MAKE) fclean
+					$(MAKE) all
+
+
+#	Include dependency files
 
 ifeq (,$(filter clean fclean re,$(MAKECMDGOALS)))
     ifneq (,$(wildcard $(OBJ_DIR)))
@@ -79,16 +145,25 @@ ifeq (,$(filter clean fclean re,$(MAKECMDGOALS)))
     endif
 endif
 
-# Custom messages
-MSG_START	:= "\033[3mBuilding \033[1;34mCrash \033[0m"
-MSG_PROGRESS:= "\033[3m🌊\033[0m"
-MSG_SUCCESS	:= "\033[1;3;36m\nDONE!\n\033[0m"
-MSG_NO_CHNG	:= "\033[3;37mEverything up-to-date!\n\033[0m"
-MSG_FAILURE	:= "\033[1;3;31mBUILD FAILED!\n\033[0m"
 
-# Makefile debugging
-print-%:
-		echo $* = $($*)
+# **************************** CUSTOM MESSAGES ******************************* #
+
+MSG_START		:=	"\033[3mBuilding \033[1;34mCrash \033[0m"
+MSG_PROGRESS	:=	"\033[3m🌊\033[0m"
+MSG_SUCCESS		:=	"\033[1;3;36m\nDONE!\n\033[0m"
+MSG_NO_CHNG		:=	"\033[3;37mEverything up-to-date!\n\033[0m"
+MSG_FAILURE		:=	"\033[1;3;31mBUILD FAILED!\n\033[0m"
+
+
+# *************************** MAKEFILE DEBUGGING ***************************** #
+
+#	Execute "make print-[variable name]" to list the variable's values
+
+print-%			:
+					echo $* = $($*)
+
+
+# ********************************* NOTES ************************************ #
 
 # test without env value:	env -i
 # detect memory leak: 		valgrind -s --leak-check=full --show-leak-kinds=all --suppressions=./minishell.supp ./minishell

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,25 @@
 NAME 		:= minishell
-INCLUDES 	:= -I./include -I./libraries/libft/inc
-LIBFT 		:= ./libraries/libft
-LIBFT_LIB 	:= libft.a
 
-BUILD_DIR	:= build/
-OBJ_DIR		:= $(BUILD_DIR)_obj/
-DEP_DIR		:= $(BUILD_DIR)_dep/
+BUILD_DIR	:= build
+OBJ_DIR		:= $(BUILD_DIR)/_obj
+DEP_DIR		:= $(BUILD_DIR)/_dep
+LIB_DIR		:= libraries
 
-CC 			:= cc
-CFLAGS 		:= -Wall -Wextra -Werror -g
-MAKEFLAGS	:= -j$(nproc)
+LIBRARIES		:= $(wildcard $(LIB_DIR)/*)
+LIBRARIES_EXT	:= readline
+INCLUDES 		:= -I./include -I./$(LIBRARIES)/inc
+
+CC 			:=	cc
+CFLAGS 		:=	-Wall -Wextra -Werror -g
+LIBFLAGS	:=	$(addprefix -L,$(LIBRARIES)) \
+                $(addprefix -l,$(patsubst lib%,%,$(notdir \
+				$(LIBRARIES) $(LIBRARIES_EXT))))
+MAKEFLAGS	:=	-j$(nproc)
 
 # TODO: need to remove forbidden wildcard
 SRC 		:= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
-OBJ 		:= $(SRC:%.c=$(OBJ_DIR)%.o)
-DEP			:= $(SRC:%.c=$(DEP_DIR)%.d)
+OBJ 		:= $(SRC:%.c=$(OBJ_DIR)/%.o)
+DEP			:= $(SRC:%.c=$(DEP_DIR)/%.d)
 
 OBJ_SUBDIRS	:= $(sort $(dir $(OBJ)))
 DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
@@ -22,25 +27,25 @@ DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
 all:		$(NAME)
 
 $(NAME):	$(OBJ)
-		$(MAKE) -C $(LIBFT)
-		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) -L$(LIBFT) -lft -lreadline -o $(NAME)
+		$(MAKE) -C $(LIBRARIES)
+		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
 
-$(OBJ_DIR)%.o:		%.c Makefile | $(OBJ_SUBDIRS)
+$(OBJ_DIR)/%.o:		%.c Makefile | $(OBJ_SUBDIRS)
 		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
-$(DEP_DIR)%.d:		%.c Makefile | $(DEP_SUBDIRS)
-		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)$*.o $@" $<
+$(DEP_DIR)/%.d:		%.c Makefile | $(DEP_SUBDIRS)
+		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
 
 $(OBJ_SUBDIRS) $(DEP_SUBDIRS):
 		mkdir -p $@
 
 clean:
-		$(MAKE) -C $(LIBFT) clean
+		$(MAKE) -C $(LIBRARIES) clean
 		rm -f $(OBJ) $(DEP)
 		-find $(OBJ_DIR) $(DEP_DIR) -type d -empty -delete
 
 fclean: 	clean
-		$(MAKE) -C $(LIBFT) fclean
+		$(MAKE) -C $(LIBRARIES) fclean
 		rm -f $(NAME)
 
 re:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CFLAGS 		:=	-Wall -Wextra -Werror -g
 LIBFLAGS	:=	$(addprefix -L,$(LIBRARIES)) \
 				$(addprefix -l,$(patsubst lib%,%,$(notdir \
 				$(LIBRARIES) $(LIBRARIES_EXT))))
-MAKEFLAGS	:=	-j
+MAKEFLAGS	:=	-j -s
 
 # TODO: need to remove forbidden wildcard
 SRC 		:= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
@@ -24,33 +24,39 @@ DEP			:= $(SRC:%.c=$(DEP_DIR)/%.d)
 OBJ_SUBDIRS	:= $(sort $(dir $(OBJ)))
 DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
 
-export 		MAKECMDGOALS
-.PHONY:		all lib clean fclean re
+export		MAKECMDGOALS
+.PHONY:		all build lib clean fclean re
+
+all:
+		($(MAKE) --question build && echo -n $(MSG_NO_CHNG)) \
+		|| (echo -n $(MSG_START) && ($(MAKE) build \
+		&& echo -n $(MSG_SUCCESS)) || echo -n $(MSG_FAILURE))
 
 ifeq ($(firstword $(sort $(MAKE_VERSION) 4.4)),4.4)
-all:		lib .WAIT $(NAME)
-
+build:		lib .WAIT $(NAME)
 else
 .NOTPARALLEL:	lib
-all:		lib $(NAME)
+build:		lib $(NAME)
+endif
 
 lib:
-	@	$(MAKE) -C $(LIBRARIES) --no-print-directory
+		$(MAKE) -C $(LIBRARIES)
 
 $(NAME):	$(LIBRARIES) $(OBJ)
 		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
 
 $(OBJ_DIR)/%.o:		%.c Makefile | $(OBJ_SUBDIRS)
-		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
+		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ \
+		&& echo -n $(MSG_PROGRESS)
 
 $(DEP_DIR)/%.d:		%.c Makefile | $(DEP_SUBDIRS)
-	@	$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
+		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
 
 $(OBJ_SUBDIRS) $(DEP_SUBDIRS):
-	@	mkdir -p $@
+		mkdir -p $@
 
 clean:
-		$(MAKE) -C $(LIBRARIES) clean
+		$(MAKE) -C $(LIBRARIES)
 		rm -f $(OBJ) $(DEP)
 ifneq (,$(wildcard $(OBJ_DIR)))
 		-find $(OBJ_DIR) -type d -empty -delete
@@ -60,7 +66,7 @@ ifneq (,$(wildcard $(DEP_DIR)))
 endif
 
 fclean: 	clean
-		$(MAKE) -C $(LIBRARIES) fclean
+		$(MAKE) -C $(LIBRARIES)
 		rm -f $(NAME)
 
 re:
@@ -73,9 +79,16 @@ ifeq (,$(filter clean fclean re,$(MAKECMDGOALS)))
     endif
 endif
 
+# Custom messages
+MSG_START	:= "\033[3mBuilding \033[1;34mCrash \033[0m"
+MSG_PROGRESS:= "\033[3m🌊\033[0m"
+MSG_SUCCESS	:= "\033[1;3;36m\nDONE!\n\033[0m"
+MSG_NO_CHNG	:= "\033[3;37mEverything up-to-date!\n\033[0m"
+MSG_FAILURE	:= "\033[1;3;31mBUILD FAILED!\n\033[0m"
+
 # Makefile debugging
 print-%:
-	@	echo $* = $($*)
+		echo $* = $($*)
 
 # test without env value:	env -i
 # detect memory leak: 		valgrind -s --leak-check=full --show-leak-kinds=all --suppressions=./minishell.supp ./minishell

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ export 		MAKECMDGOALS
 all:		lib $(NAME)
 
 lib:
-		$(MAKE) -C $(LIBRARIES)
+	@	$(MAKE) -C $(LIBRARIES) --no-print-directory
 
 $(NAME):	$(LIBRARIES) $(OBJ)
 		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
@@ -43,10 +43,10 @@ $(OBJ_DIR)/%.o:		%.c Makefile | $(OBJ_SUBDIRS)
 		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 $(DEP_DIR)/%.d:		%.c Makefile | $(DEP_SUBDIRS)
-		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
+	@	$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
 
 $(OBJ_SUBDIRS) $(DEP_SUBDIRS):
-		mkdir -p $@
+	@	mkdir -p $@
 
 clean:
 		$(MAKE) -C $(LIBRARIES) clean

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ LIBFT_LIB 	:= libft.a
 
 CC 			:= cc
 CFLAGS 		:= -Wall -Wextra -Werror -g
+MAKEFLAGS	:= -j$(nproc)
 
 # TODO: need to remove forbidden wildcard
 SRC 		= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
@@ -27,7 +28,9 @@ fclean: 	clean
 		$(MAKE) -C $(LIBFT) fclean
 		rm -f $(NAME)
 
-re: 	fclean all
+re:
+		$(MAKE) fclean
+		$(MAKE) all
 
 .PHONY: all clean fclean re
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
 export 		MAKECMDGOALS
 .PHONY:		all lib clean fclean re
 
+# Needs GNU Make version 4.4
+# all:		lib .WAIT $(NAME)	(Replaces .NOTPARALLEL special target)
+.NOTPARALLEL:	lib	# temporary until update to version 4.4
+
 all:		lib $(NAME)
 
 lib:

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ INCLUDES 	:= -I./include -I./libraries/libft/inc
 LIBFT 		:= ./libraries/libft
 LIBFT_LIB 	:= libft.a
 
-B			:= build/
-O			:= $B_obj/
-D			:= $B_dep/
+BUILD_DIR	:= build/
+OBJ_DIR		:= $(BUILD_DIR)_obj/
+DEP_DIR		:= $(BUILD_DIR)_dep/
 
 CC 			:= cc
 CFLAGS 		:= -Wall -Wextra -Werror -g
@@ -13,11 +13,11 @@ MAKEFLAGS	:= -j$(nproc)
 
 # TODO: need to remove forbidden wildcard
 SRC 		:= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)
-OBJ 		:= $(SRC:%.c=$O%.o)
-DEP			:= $(SRC:%.c=$D%.d)
+OBJ 		:= $(SRC:%.c=$(OBJ_DIR)%.o)
+DEP			:= $(SRC:%.c=$(DEP_DIR)%.d)
 
-SUBDIRS_O	:= $(sort $(dir $(OBJ)))
-SUBDIRS_D	:= $(sort $(dir $(DEP)))
+OBJ_SUBDIRS	:= $(sort $(dir $(OBJ)))
+DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
 
 all:		$(NAME)
 
@@ -25,19 +25,19 @@ $(NAME):	$(OBJ)
 		$(MAKE) -C $(LIBFT)
 		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) -L$(LIBFT) -lft -lreadline -o $(NAME)
 
-$O%.o:		%.c Makefile | $(SUBDIRS_O)
+$(OBJ_DIR)%.o:		%.c Makefile | $(OBJ_SUBDIRS)
 		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
-$D%.d:		%.c Makefile | $(SUBDIRS_D)
-		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$O$*.o $@" $<
+$(DEP_DIR)%.d:		%.c Makefile | $(DEP_SUBDIRS)
+		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$(OBJ_DIR)$*.o $@" $<
 
-$(SUBDIRS_O) $(SUBDIRS_D):
+$(OBJ_SUBDIRS) $(DEP_SUBDIRS):
 		mkdir -p $@
 
 clean:
 		$(MAKE) -C $(LIBFT) clean
 		rm -f $(OBJ) $(DEP)
-		-find $O $D -type d -empty -delete
+		-find $(OBJ_DIR) $(DEP_DIR) -type d -empty -delete
 
 fclean: 	clean
 		$(MAKE) -C $(LIBFT) fclean
@@ -50,7 +50,7 @@ re:
 .PHONY: all clean fclean re
 
 ifeq (,$(filter clean fclean re,$(MAKECMDGOALS)))
-    ifneq (,$(wildcard $O))
+    ifneq (,$(wildcard $(OBJ_DIR)))
         -include	$(DEP)
     endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ $(NAME):	$(OBJ)
 		$(MAKE) -C $(LIBFT)
 		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) -L$(LIBFT) -lft -lreadline -o $(NAME)
 
-$O%.o:		%.c | $(SUBDIRS_O)
+$O%.o:		%.c Makefile | $(SUBDIRS_O)
 		$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
-$D%.d:		%.c | $(SUBDIRS_D)
+$D%.d:		%.c Makefile | $(SUBDIRS_D)
 		$(CC) $(CFLAGS) $(INCLUDES) -M -MP -MF $@ -MT "$O$*.o $@" $<
 
 $(SUBDIRS_O) $(SUBDIRS_D):

--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,9 @@ ifeq (,$(filter clean fclean re,$(MAKECMDGOALS)))
     endif
 endif
 
+# Makefile debugging
+print-%:
+	@	echo $* = $($*)
+
 # test without env value:	env -i
 # detect memory leak: 		valgrind -s --leak-check=full --show-leak-kinds=all --suppressions=./minishell.supp ./minishell

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CFLAGS 		:=	-Wall -Wextra -Werror -g
 LIBFLAGS	:=	$(addprefix -L,$(LIBRARIES)) \
 				$(addprefix -l,$(patsubst lib%,%,$(notdir \
 				$(LIBRARIES) $(LIBRARIES_EXT))))
-MAKEFLAGS	:=	-j$(nproc)
+MAKEFLAGS	:=	-j
 
 # TODO: need to remove forbidden wildcard
 SRC 		:= $(wildcard source/*.c source/*/*.c source/*/*/*.c tests/*.c)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ INCLUDES 		:= -I./include -I./$(LIBRARIES)/inc
 CC 			:=	cc
 CFLAGS 		:=	-Wall -Wextra -Werror -g
 LIBFLAGS	:=	$(addprefix -L,$(LIBRARIES)) \
-                $(addprefix -l,$(patsubst lib%,%,$(notdir \
+				$(addprefix -l,$(patsubst lib%,%,$(notdir \
 				$(LIBRARIES) $(LIBRARIES_EXT))))
 MAKEFLAGS	:=	-j$(nproc)
 
@@ -24,10 +24,15 @@ DEP			:= $(SRC:%.c=$(DEP_DIR)/%.d)
 OBJ_SUBDIRS	:= $(sort $(dir $(OBJ)))
 DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
 
-all:		$(NAME)
+export 		MAKECMDGOALS
+.PHONY:		all lib clean fclean re
 
-$(NAME):	$(OBJ)
+all:		lib $(NAME)
+
+lib:
 		$(MAKE) -C $(LIBRARIES)
+
+$(NAME):	$(LIBRARIES) $(OBJ)
 		$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
 
 $(OBJ_DIR)/%.o:		%.c Makefile | $(OBJ_SUBDIRS)
@@ -51,8 +56,6 @@ fclean: 	clean
 re:
 		$(MAKE) fclean
 		$(MAKE) all
-
-.PHONY: all clean fclean re
 
 ifeq (,$(filter clean fclean re,$(MAKECMDGOALS)))
     ifneq (,$(wildcard $(OBJ_DIR)))

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,11 @@ DEP_SUBDIRS	:= $(sort $(dir $(DEP)))
 export 		MAKECMDGOALS
 .PHONY:		all lib clean fclean re
 
-# Needs GNU Make version 4.4
-# all:		lib .WAIT $(NAME)	(Replaces .NOTPARALLEL special target)
-.NOTPARALLEL:	lib	# temporary until update to version 4.4
+ifeq ($(firstword $(sort $(MAKE_VERSION) 4.4)),4.4)
+all:		lib .WAIT $(NAME)
 
+else
+.NOTPARALLEL:	lib
 all:		lib $(NAME)
 
 lib:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,12 @@ $(OBJ_SUBDIRS) $(DEP_SUBDIRS):
 clean:
 		$(MAKE) -C $(LIBRARIES) clean
 		rm -f $(OBJ) $(DEP)
-		-find $(OBJ_DIR) $(DEP_DIR) -type d -empty -delete
+ifneq (,$(wildcard $(OBJ_DIR)))
+		-find $(OBJ_DIR) -type d -empty -delete
+endif
+ifneq (,$(wildcard $(DEP_DIR)))
+		-find $(DEP_DIR) -type d -empty -delete
+endif
 
 fclean: 	clean
 		$(MAKE) -C $(LIBRARIES) fclean


### PR DESCRIPTION
Add the following improvements to the Makefile:
1. Massively improve build speed by letting 'make' use more CPU cores.
    - Added rule to automatically detect which features of Make can be used depending on which version is installed.

2. Separate build artifact files (\*.o/\*.d) into a separate directory.

3. Add dependency file creation to Makefile.
    - Now, whenever something in a header file changes, all source files that include this header file will recompile, even if nothing in the source files themselves changed.
    - This works by telling the compiler to separate the compilation process into 3 stages:
     i.   Pre-processing:
          Creates .d files which keep track of all header file dependencies.
     ii.  Compiling:
          Compiles the source files into object files.
     iii. Linking:
          Links the object files into an executable.

4. Add a print rule for Makefile debugging.

5. Let the project recompile when the Makefile changes.

6. Let the project recompile when any library files change. 

7. Replace default print-outs with custom messages (🌊).

8. Improve readability of the Makefile by changing the layout and adding more whitespace and comments.