### PR TITLE
[CI] Improve the order of the GH Actions result-comparison steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
 
     - name: Compare failed count
       run: |
-        echo "PR_FAILED_COUNT: $PR_FAILED_COUNT"
         echo "MAIN_FAILED_COUNT: $MAIN_FAILED_COUNT"
+        echo "PR_FAILED_COUNT: $PR_FAILED_COUNT"
         if [ $PR_FAILED_COUNT -gt $MAIN_FAILED_COUNT ]; then
           echo "PR_FAILED_COUNT is greater than MAIN_FAILED_COUNT"
           exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,8 @@ jobs:
       env:
         GH_BRANCH: "MAIN_FAILED_COUNT"
 
-    - name: Compare the difference between PR and main
-      run: diff $HOME/main_test_result.txt $HOME/pr_test_result.txt || true
-
     - name: Compare failed count
+      id: comparison
       run: |
         echo "MAIN_FAILED_COUNT: $MAIN_FAILED_COUNT"
         echo "PR_FAILED_COUNT: $PR_FAILED_COUNT"
@@ -70,3 +68,14 @@ jobs:
       env:
         PR_FAILED_COUNT: ${{ env.PR_FAILED_COUNT }}
         MAIN_FAILED_COUNT: ${{ env.MAIN_FAILED_COUNT }}
+      continue-on-error: true
+
+      # Can fail the job
+    - name: Compare the regression between PR and main
+      if: steps.comparison.outcome == 'failure'
+      run: diff $HOME/main_test_result.txt $HOME/pr_test_result.txt
+
+      # Cannot fail the job
+    - name: Compare the improvement between PR and main
+      if: steps.comparison.outcome == 'success'
+      run: diff $HOME/main_test_result.txt $HOME/pr_test_result.txt || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,11 +71,11 @@ jobs:
       continue-on-error: true
 
       # Can fail the job
-    - name: Compare the regression between PR and main
+    - name: Show the regressions between PR and main
       if: steps.comparison.outcome == 'failure'
       run: diff $HOME/main_test_result.txt $HOME/pr_test_result.txt
 
       # Cannot fail the job
-    - name: Compare the improvement between PR and main
+    - name: Show the improvements between PR and main
       if: steps.comparison.outcome == 'success'
       run: diff $HOME/main_test_result.txt $HOME/pr_test_result.txt || true


### PR DESCRIPTION
#### The MAIN_FAILED_COUNT will now be printed before the PR_FAILED_COUNT.
  - This is easier to read and in line with the order of the diffs.
  
#### The diff step will now be run after the comparison of the FAILED_COUNTs.
  - This makes it easier to quickly check the FAILED_COUNTs, and then see the exact differences.
  
  - If the result got worse, now both the comparison step and the diff step will show a red X in the Actions tab.
    - This is done by letting the job continue even after the comparison of the FAILED_COUNTS exits with error. 
    The following diff will then always stop the job.