### PR TITLE
[CI] Revert the commits that let the GH Actions not prevent a merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
       # Can fail the job
     - name: Show the regressions between PR and main
       if: steps.comparison.outcome == 'failure'
-      run: diff $HOME/main_test_result.txt $HOME/pr_test_result.txt || true
+      run: diff $HOME/main_test_result.txt $HOME/pr_test_result.txt
 
       # Cannot fail the job
     - name: Show the improvements between PR and main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,6 @@ jobs:
     steps:
     - name: Checkout repository to incoming PR
       uses: actions/checkout@v4
-    
-    - name: Clean the storage
-      run: |
-        rm -rf $HOME/42_minishell_tester
-        rm -rf $HOME/pr_test_result*.txt
-        rm -rf $HOME/main_test_result*.txt
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: Set up build environment
       run: |


### PR DESCRIPTION
From now on the test results should not get any worse anymore.
And the storage space issue was caused by infinitely long log files bc we didn't have pipe redirection yet.