### PR TITLE
[FIX]  Wait for all children in pipeline to finish before exiting

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 15:56:26 by lyeh              #+#    #+#             */
-/*   Updated: 2024/01/18 23:46:08 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/01/25 16:24:17 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -277,13 +277,14 @@ new_pipe: read=fd, write=fd
 */
 typedef struct s_shell
 {
-	int				pid;
-	int				subshell_pid;
+	pid_t			pid;
+	pid_t			subshell_pid;
 	int				subshell_level;
 	t_pipe			old_pipe;
 	t_pipe			new_pipe;
 	int				exit_status;
 	int				exit_code;
+	t_list			*child_pid_list;
 	t_list			*env_list;
 	t_list			*token_list;
 	t_list_d		*cmd_table_list;

--- a/include/defines.h
+++ b/include/defines.h
@@ -19,6 +19,7 @@
 # include <sysexits.h>
 # include <sys/stat.h>
 # include <sys/wait.h>
+# include <errno.h>
 # include <unistd.h>
 # include <stdio.h>
 # include <stdlib.h>
@@ -44,6 +45,7 @@
 # define EXIT_SIGTERM       130
 # define PREPROCESS_ERROR   195
 # define SUBSHELL_ERROR     196
+# define IO_RED_ERROR       197
 
 /* Parsing Table */
 # define PT_COL_SIZE        5

--- a/include/executor.h
+++ b/include/executor.h
@@ -39,7 +39,9 @@ bool	check_file(char *filename, int o_flag, int permission);
 char	*get_exec_path(char *cmd_name, char **envp);
 
 /* Redirection */
-bool	bind_to_stdio(t_shell *shell, t_final_cmd_table *final_cmd_table);
+bool	restore_std_io(int saved_std_io[2]);
+bool	save_std_io(int saved_std_io[2]);
+bool	redirect_io(t_shell *shell, t_final_cmd_table *final_cmd_table);
 bool	handle_io_redirect(
 			t_final_cmd_table *final_cmd_table, t_list *io_red_node);
 

--- a/include/executor.h
+++ b/include/executor.h
@@ -25,9 +25,11 @@ void	handle_control_op(t_shell *shell, t_list_d **cmd_table_node);
 void	handle_pipeline(t_shell *shell, t_list_d **cmd_table_list);
 void	handle_simple_cmd(t_shell *shell, t_list_d **cmd_table_list);
 void	handle_assignment(t_shell *shell, t_final_cmd_table *final_cmd_table);
-void	handle_external_cmd(t_shell *shell, t_final_cmd_table *final_cmd_table);
-void	handle_builtin(t_shell *shell,
-			t_list_d **cmd_table_node, t_final_cmd_table *final_cmd_table);
+// void	handle_external_cmd(t_shell *shell, t_final_cmd_table *final_cmd_table);
+void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table);
+void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node);
+// void	handle_builtin(t_shell *shell,
+// 			t_list_d **cmd_table_node, t_final_cmd_table *final_cmd_table);
 
 /* Error checker */
 bool	check_executable(t_shell *shell, char *filename);
@@ -38,6 +40,8 @@ char	*get_exec_path(char *cmd_name, char **envp);
 
 /* Redirection */
 bool	bind_to_stdio(t_shell *shell, t_final_cmd_table *final_cmd_table);
+bool	handle_io_redirect(
+			t_final_cmd_table *final_cmd_table, t_list *io_red_node);
 
 /* Redirection - Pipe */
 bool	need_pipe(t_list_d *cmd_table_node);
@@ -47,6 +51,6 @@ void	handle_pipes_parent(t_pipe *new_pipe, t_pipe *old_pipe);
 void	handle_pipes_child(t_pipe *new_pipe, t_pipe *old_pipe);
 void	safe_close_all_pipes(t_shell *shell);
 // void	safe_move_nonempty_pipe(t_pipe *from, t_pipe *to);
-void	replace_pipe_end(int *from_end, int *to_end);
+void	replace_fd(int *from_end, int *to_end);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/17 13:38:17 by lyeh              #+#    #+#             */
-/*   Updated: 2024/01/23 03:33:57 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/01/25 16:25:19 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,7 @@ char		**convert_list_to_string_array(t_list *list);
 char		**append_string_array(char **array, char *str);
 
 /* Process utils */
-void		wait_process(t_shell *shell, int pid);
+void		wait_process(t_shell *shell, pid_t pid);
 int			status(int wstatus);
 
 /* Type utils */

--- a/include/utils.h
+++ b/include/utils.h
@@ -32,6 +32,7 @@ void		free_ast_data(t_ast *ast);
 /* Redirect utils */
 t_io_red	*init_io_red(void);
 void		free_io_red(t_io_red *io_red);
+int			get_redirect_type_from_list(t_list *io_red_list);
 
 /* Cmd table utils */
 t_cmd_table	*init_cmd_table(void);

--- a/include/utils.h
+++ b/include/utils.h
@@ -43,6 +43,7 @@ bool		append_cmd_table_by_scenario(
 				int token_type, t_list_d **cmd_table_list);
 t_cmd_table	*get_cmd_table_from_list(t_list_d *cmd_table_node);
 int			get_cmd_table_type_from_list(t_list_d *cmd_table_list);
+char		*get_cmd_name_from_list(t_list *simple_cmd_list);
 bool		is_control_op_cmd_table(int cmd_table_type);
 bool		is_builtin(char *cmd_name);
 bool		is_scmd_in_pipeline(t_list_d *cmd_table_node);

--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/16 13:33:38 by ldulling          #+#    #+#              #
-#    Updated: 2024/01/18 01:54:20 by ldulling         ###   ########.fr        #
+#    Updated: 2024/01/25 16:11:32 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -68,6 +68,7 @@ TMP		+=	$(addprefix $(DIR)$(SUBDIR), \
 			ft_lstmap.c \
 			ft_lstnew.c \
 			ft_lstnew_back.c \
+			ft_lstnew_front.c \
 			ft_lstpop_front.c \
 			ft_lstpop_front_content.c \
 			ft_lstsize.c \

--- a/libraries/libft/inc/libft.h
+++ b/libraries/libft/inc/libft.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/24 16:17:46 by ldulling          #+#    #+#             */
-/*   Updated: 2024/01/18 01:54:09 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/01/25 16:11:26 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,7 @@ t_list		*ft_lstlast(t_list *lst);
 t_list		*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *));
 t_list		*ft_lstnew(void *content);
 bool		ft_lstnew_back(t_list **lst, void *content);
+bool		ft_lstnew_front(t_list **lst, void *content);
 t_list		*ft_lstpop_front(t_list **lst);
 void		*ft_lstpop_front_content(t_list **lst);
 int			ft_lstsize(t_list *lst);

--- a/libraries/libft/src/libft/lists/singly_linked/ft_lstnew_front.c
+++ b/libraries/libft/src/libft/lists/singly_linked/ft_lstnew_front.c
@@ -1,0 +1,35 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_lstnew_front.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/25 16:09:14 by ldulling          #+#    #+#             */
+/*   Updated: 2024/01/25 16:09:17 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+/**
+ * The ft_lstnew_front function creates a new node with the provided content and
+ * adds it to the beginning of the singly linked list.
+ *
+ * @param lst     The address of the list to add the new node to.
+ * @param content The content to be added to the new node.
+ *
+ * @return        Returns true if the new node was successfully added, false if
+ *                malloc failed.
+ *
+ */
+bool	ft_lstnew_front(t_list **lst, void *content)
+{
+	t_list	*new_node;
+
+	new_node = ft_lstnew(content);
+	if (new_node == NULL)
+		return (false);
+	ft_lstadd_front(lst, new_node);
+	return (true);
+}

--- a/source/backend/executor/exec_error.c
+++ b/source/backend/executor/exec_error.c
@@ -30,18 +30,3 @@ bool	check_executable(t_shell *shell, char *filename)
 	}
 	return (true);
 }
-
-bool	check_file(char *filename, int o_flag, int permission)
-{
-	int	fd;
-
-	fd = open(filename, o_flag, permission);
-	if (fd == -1)
-	{
-		ft_dprintf(2, "%s: %s: ", PROGRAM_NAME, filename);
-		perror("");
-		return (false);
-	}
-	close(fd);
-	return (true);
-}

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -55,19 +55,21 @@ bool	pre_expand_simple_cmd(t_shell *shell, t_list_d *cmd_table_node)
 	t_list		*expanded_list;
 	int			ret;
 
-	expanded_list = NULL;
 	while (cmd_table_node)
 	{
-		cmd_table = cmd_table_node->content;
-		if (!cmd_table->simple_cmd_list)
-			return (true);
-		ret = expand_list(shell, cmd_table->simple_cmd_list, &expanded_list);
-		if (ret == SUBSHELL_ERROR)
-			return (ft_lstclear(&expanded_list, free), false);
-		else if (ret == BAD_SUBSTITUTION)
-			ft_lstclear(&expanded_list, free);
-		ft_lstclear(&cmd_table->simple_cmd_list, free);
-		cmd_table->simple_cmd_list = expanded_list;
+		expanded_list = NULL;
+		if (get_cmd_table_type_from_list(cmd_table_node) == C_SIMPLE_CMD)
+		{
+			cmd_table = cmd_table_node->content;
+			ret = expand_list(
+					shell, cmd_table->simple_cmd_list, &expanded_list);
+			if (ret == SUBSHELL_ERROR)
+				return (ft_lstclear(&expanded_list, free), false);
+			else if (ret == BAD_SUBSTITUTION)
+				ft_lstclear(&expanded_list, free);
+			ft_lstclear(&cmd_table->simple_cmd_list, free);
+			cmd_table->simple_cmd_list = expanded_list;
+		}
 		cmd_table_node = cmd_table_node->next;
 	}
 	return (true);

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -16,9 +16,21 @@
 #include "utils.h"
 #include "debug.h"
 
+void	handle_cmd_execution(t_shell *shell, t_list_d **cmd_table_node)
+{
+	t_cmd_table	*cmd_table;
+
+	cmd_table = (*cmd_table_node)->content;
+	if (is_builtin(get_cmd_name_from_list(cmd_table->simple_cmd_list)) && \
+		!is_scmd_in_pipeline(*cmd_table_node))
+		handle_builtin(shell, cmd_table_node);
+	else
+		handle_pipeline(shell, cmd_table_node);
+}
+
 void	handle_process(t_shell *shell, t_list_d *cmd_table_node)
 {
-	t_cmd_table			*cmd_table;
+	t_cmd_table	*cmd_table;
 
 	while (cmd_table_node)
 	{
@@ -28,13 +40,7 @@ void	handle_process(t_shell *shell, t_list_d *cmd_table_node)
 		else if (is_control_op_cmd_table(cmd_table->type))
 			handle_control_op(shell, &cmd_table_node);
 		else if (cmd_table->type == C_SIMPLE_CMD)
-		{
-			if (is_builtin(cmd_table->simple_cmd_list->content) && \
-				!is_scmd_in_pipeline(cmd_table_node))
-				handle_builtin(shell, &cmd_table_node);
-			else
-				handle_pipeline(shell, &cmd_table_node);
-		}
+			handle_cmd_execution(shell, &cmd_table_node);
 		else if (cmd_table->type == C_SUBSHELL_START)
 			handle_pipeline(shell, &cmd_table_node);
 		else

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/26 15:04:52 by lyeh              #+#    #+#             */
-/*   Updated: 2024/01/19 22:48:58 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/01/24 02:38:15 by lyeh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,27 +15,6 @@
 #include "clean.h"
 #include "utils.h"
 #include "debug.h"
-
-void	handle_cmd_execution(t_shell *shell, t_list_d **cmd_table_node)
-{
-	t_final_cmd_table	*final_cmd_table;
-
-	final_cmd_table = get_final_cmd_table(shell, (*cmd_table_node)->content);
-	if (!final_cmd_table)
-		ft_clean_and_exit_shell(
-			shell, PREPROCESS_ERROR, "final cmd table malloc failed");
-	if (is_builtin(final_cmd_table->simple_cmd[0]) && \
-		!is_scmd_in_pipeline(*cmd_table_node))
-	{
-		handle_builtin(shell, cmd_table_node, final_cmd_table);
-		free_final_cmd_table(&final_cmd_table);
-	}
-	else
-	{
-		free_final_cmd_table(&final_cmd_table);
-		handle_pipeline(shell, cmd_table_node);
-	}
-}
 
 void	handle_process(t_shell *shell, t_list_d *cmd_table_node)
 {
@@ -49,7 +28,13 @@ void	handle_process(t_shell *shell, t_list_d *cmd_table_node)
 		else if (is_control_op_cmd_table(cmd_table->type))
 			handle_control_op(shell, &cmd_table_node);
 		else if (cmd_table->type == C_SIMPLE_CMD)
-			handle_cmd_execution(shell, &cmd_table_node);
+		{
+			if (is_builtin(cmd_table->simple_cmd_list->content) && \
+				!is_scmd_in_pipeline(cmd_table_node))
+				handle_builtin(shell, &cmd_table_node);
+			else
+				handle_pipeline(shell, &cmd_table_node);
+		}
 		else if (cmd_table->type == C_SUBSHELL_START)
 			handle_pipeline(shell, &cmd_table_node);
 		else
@@ -58,11 +43,37 @@ void	handle_process(t_shell *shell, t_list_d *cmd_table_node)
 	}
 }
 
+bool	pre_expand_simple_cmd(t_shell *shell, t_list_d *cmd_table_node)
+{
+	t_cmd_table	*cmd_table;
+	t_list		*expanded_list;
+	int			ret;
+
+	expanded_list = NULL;
+	while (cmd_table_node)
+	{
+		cmd_table = cmd_table_node->content;
+		if (!cmd_table->simple_cmd_list)
+			return (true);
+		ret = expand_list(shell, cmd_table->simple_cmd_list, &expanded_list);
+		if (ret == SUBSHELL_ERROR)
+			return (ft_lstclear(&expanded_list, free), false);
+		else if (ret == BAD_SUBSTITUTION)
+			ft_lstclear(&expanded_list, free);
+		ft_lstclear(&cmd_table->simple_cmd_list, free);
+		cmd_table->simple_cmd_list = expanded_list;
+		cmd_table_node = cmd_table_node->next;
+	}
+	return (true);
+}
+
 // TODO: activate signal listener in the child process
 void	ft_executor(t_shell *shell)
 {
-	if (!ft_heredoc(shell->cmd_table_list))
+	if (!ft_heredoc(shell->cmd_table_list) || \
+		!pre_expand_simple_cmd(shell, shell->cmd_table_list))
 		ft_clean_and_exit_shell(
-			shell, PREPROCESS_ERROR, "heredoc malloc failed");
+			shell, PREPROCESS_ERROR, "heredoc/expend malloc failed");
+	print_cmd_table_list(shell->cmd_table_list);
 	handle_process(shell, shell->cmd_table_list);
 }

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -33,10 +33,13 @@ void	exec_builtin_cmd(t_shell *shell, t_final_cmd_table *final_cmd_table)
 		exec_exit(shell, final_cmd_table);
 }
 
-void	handle_builtin(t_shell *shell,
-			t_list_d **cmd_table_node, t_final_cmd_table *final_cmd_table)
+void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 {
-	shell->subshell_pid = 0;
+	t_final_cmd_table	*final_cmd_table;
+
+	final_cmd_table = get_final_cmd_table(shell, (*cmd_table_node)->content);
+	if (!final_cmd_table)
+		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 	if (!bind_to_stdio(shell, final_cmd_table))
 	{
 		free_final_cmd_table(&final_cmd_table);

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -46,5 +46,6 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 	}
 	exec_builtin_cmd(shell, final_cmd_table);
+	free_final_cmd_table(&final_cmd_table);
 	*cmd_table_node = (*cmd_table_node)->next;
 }

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -38,14 +38,17 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 	t_final_cmd_table	*final_cmd_table;
 
 	final_cmd_table = get_final_cmd_table(shell, (*cmd_table_node)->content);
-	if (!final_cmd_table)
-		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
-	if (!bind_to_stdio(shell, final_cmd_table))
+	if (final_cmd_table)
 	{
+		if (!bind_to_stdio(shell, final_cmd_table))
+		{
+			free_final_cmd_table(&final_cmd_table);
+			ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
+		}
+		exec_builtin_cmd(shell, final_cmd_table);
 		free_final_cmd_table(&final_cmd_table);
-		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 	}
-	exec_builtin_cmd(shell, final_cmd_table);
-	free_final_cmd_table(&final_cmd_table);
+	else if (shell->exit_code == SUBSHELL_ERROR)
+		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 	*cmd_table_node = (*cmd_table_node)->next;
 }

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -10,6 +10,7 @@ void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 	final_cmd_table = get_final_cmd_table(shell, cmd_table);
 	if (!final_cmd_table)
 		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
+	print_final_cmd_table(final_cmd_table);
 	if (!bind_to_stdio(shell, final_cmd_table) || \
 		!check_executable(shell, final_cmd_table->exec_path))
 	{

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -1,9 +1,15 @@
 #include "executor.h"
 #include "utils.h"
 #include "clean.h"
+#include "debug.h"
 
-void	handle_external_cmd(t_shell *shell, t_final_cmd_table *final_cmd_table)
+void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 {
+	t_final_cmd_table	*final_cmd_table;
+
+	final_cmd_table = get_final_cmd_table(shell, cmd_table);
+	if (!final_cmd_table)
+		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 	if (!bind_to_stdio(shell, final_cmd_table) || \
 		!check_executable(shell, final_cmd_table->exec_path))
 	{

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -3,20 +3,6 @@
 #include "clean.h"
 #include "debug.h"
 
-void	bind_io_and_exec_external(
-	t_shell *shell, t_final_cmd_table *final_cmd_table)
-{
-	if (!redirect_io(shell, final_cmd_table))
-	{
-		free_final_cmd_table(&final_cmd_table);
-		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
-	}
-	execve(final_cmd_table->exec_path, final_cmd_table->simple_cmd,
-		final_cmd_table->envp);
-	free_final_cmd_table(&final_cmd_table);
-	ft_clean_and_exit_shell(shell, CMD_EXEC_FAILED, "execve failed");
-}
-
 void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 {
 	t_final_cmd_table	*final_cmd_table;

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -3,6 +3,20 @@
 #include "clean.h"
 #include "debug.h"
 
+void	bind_io_and_exec_external(
+	t_shell *shell, t_final_cmd_table *final_cmd_table)
+{
+	if (!redirect_io(shell, final_cmd_table))
+	{
+		free_final_cmd_table(&final_cmd_table);
+		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
+	}
+	execve(final_cmd_table->exec_path, final_cmd_table->simple_cmd,
+		final_cmd_table->envp);
+	free_final_cmd_table(&final_cmd_table);
+	ft_clean_and_exit_shell(shell, CMD_EXEC_FAILED, "execve failed");
+}
+
 void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 {
 	t_final_cmd_table	*final_cmd_table;
@@ -11,7 +25,7 @@ void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 	if (!final_cmd_table)
 		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 	print_final_cmd_table(final_cmd_table);
-	if (!bind_to_stdio(shell, final_cmd_table) || \
+	if (!redirect_io(shell, final_cmd_table) || \
 		!check_executable(shell, final_cmd_table->exec_path))
 	{
 		free_final_cmd_table(&final_cmd_table);

--- a/source/backend/executor/handle_pipeline.c
+++ b/source/backend/executor/handle_pipeline.c
@@ -18,7 +18,6 @@ void	exec_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 {
 	int	cmd_table_type;
 
-	// safe_move_nonempty_pipe(&shell->new_pipe, &shell->old_pipe);
 	cmd_table_type = get_cmd_table_type_from_list(*cmd_table_node);
 	while (cmd_table_type != C_AND && cmd_table_type != C_OR && \
 		cmd_table_type != C_SUBSHELL_END && cmd_table_type != C_NONE)

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -40,7 +40,7 @@ void	exec_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 	if (!cmd_table)
 		ft_clean_and_exit_shell(
 			shell, SUBSHELL_ERROR, "get_cmd_table_from_list failed");
-	cmd_name = cmd_table->simple_cmd_list->content;
+	cmd_name = get_cmd_name_from_list(cmd_table->simple_cmd_list);
 	if (cmd_name == NULL)
 		printf("\n");
 	else if (is_builtin(cmd_name))

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -33,21 +33,20 @@
 */
 void	exec_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 {
-	t_cmd_table			*cmd_table;
-	t_final_cmd_table	*final_cmd_table;
+	t_cmd_table	*cmd_table;
+	char		*cmd_name;
 
 	cmd_table = get_cmd_table_from_list(*cmd_table_node);
-	final_cmd_table = get_final_cmd_table(shell, cmd_table);
-	if (!final_cmd_table)
+	if (!cmd_table)
 		ft_clean_and_exit_shell(
-			shell, SUBSHELL_ERROR, "get_final_cmd_table failed");
-	if (final_cmd_table->simple_cmd[0] == NULL)
+			shell, SUBSHELL_ERROR, "get_cmd_table_from_list failed");
+	cmd_name = cmd_table->simple_cmd_list->content;
+	if (cmd_name == NULL)
 		printf("\n");
-	else if (is_builtin(final_cmd_table->simple_cmd[0]))
-		handle_builtin(shell, cmd_table_node, final_cmd_table);
+	else if (is_builtin(cmd_name))
+		handle_builtin(shell, cmd_table_node);
 	else
-		handle_external_cmd(shell, final_cmd_table);
-	free_final_cmd_table(&final_cmd_table);
+		handle_external_cmd(shell, cmd_table);
 	ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 }
 

--- a/source/backend/redirection/bind.c
+++ b/source/backend/redirection/bind.c
@@ -8,12 +8,14 @@ bool	bind_to_stdio(t_shell *shell, t_final_cmd_table *final_cmd_table)
 	if (dup2(final_cmd_table->read_fd, STDIN_FILENO) == -1 || \
 		dup2(final_cmd_table->write_fd, STDOUT_FILENO) == -1)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		ft_dprintf(STDERR_FILENO, "haha %s: ", PROGRAM_NAME);
 		perror(final_cmd_table->simple_cmd[0]);
 		ret = false;
 	}
 	else
 		ret = true;
 	safe_close_all_pipes(shell);
+	safe_close(&final_cmd_table->read_fd);
+	safe_close(&final_cmd_table->write_fd);
 	return (ret);
 }

--- a/source/backend/redirection/bind.c
+++ b/source/backend/redirection/bind.c
@@ -1,21 +1,58 @@
 #include "executor.h"
 #include "utils.h"
 
-bool	bind_to_stdio(t_shell *shell, t_final_cmd_table *final_cmd_table)
+bool	save_std_io(int saved_std_io[2])
+{
+	saved_std_io[0] = dup(STDIN_FILENO);
+	saved_std_io[1] = dup(STDOUT_FILENO);
+	if (saved_std_io[0] == -1 || saved_std_io[1] == -1)
+	{
+		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		perror(NULL);
+		safe_close(&saved_std_io[0]);
+		safe_close(&saved_std_io[1]);
+		return (false);
+	}
+	return (true);
+}
+
+bool	redirect_io(t_shell *shell, t_final_cmd_table *final_cmd_table)
 {
 	bool	ret;
 
+	ret = true;
 	if (dup2(final_cmd_table->read_fd, STDIN_FILENO) == -1 || \
 		dup2(final_cmd_table->write_fd, STDOUT_FILENO) == -1)
 	{
-		ft_dprintf(STDERR_FILENO, "haha %s: ", PROGRAM_NAME);
-		perror(final_cmd_table->simple_cmd[0]);
+		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		perror(NULL);
 		ret = false;
 	}
-	else
-		ret = true;
-	safe_close_all_pipes(shell);
-	safe_close(&final_cmd_table->read_fd);
-	safe_close(&final_cmd_table->write_fd);
+	if (shell->subshell_level != 0)
+	{
+		safe_close_all_pipes(shell);
+		safe_close(&final_cmd_table->read_fd);
+		safe_close(&final_cmd_table->write_fd);
+	}
 	return (ret);
+}
+
+bool	restore_std_io(int saved_std_io[2])
+{
+	bool	error;
+
+	error = false;
+	if (saved_std_io[0] != -1)
+		if (dup2(saved_std_io[0], STDIN_FILENO) == -1)
+			error = true;
+	if (!error && saved_std_io[1] != -1)
+		if (dup2(saved_std_io[1], STDOUT_FILENO) == -1)
+			error = true;
+	if (error)
+	{
+		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		perror(NULL);
+		return (false);
+	}
+	return (true);
 }

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -44,7 +44,7 @@ bool	exec_heredoc(int cmdtable_id, t_io_red **io_red)
 		{
 			ft_dprintf(STDERR_FILENO, ERROR_HEREDOC_UNEXPECTED_EOF,
 				PROGRAM_NAME, (*io_red)->here_end);
-			return (remove_file((*io_red)->in_file), true);
+			return (true);
 		}
 		if (ft_strcmp(line, (*io_red)->here_end) == 0)
 			break ;

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -17,16 +17,16 @@ bool	setup_tmp_hdfile(int cmdtable_id, t_io_red **io_red)
 {
 	int	fd;
 
-	(*io_red)->out_file = generate_tmp_filename(cmdtable_id, "hd");
-	if (!(*io_red)->out_file)
+	(*io_red)->in_file = generate_tmp_filename(cmdtable_id, "hd");
+	if (!(*io_red)->in_file)
 		return (false);
-	fd = open((*io_red)->out_file,
+	fd = open((*io_red)->in_file,
 			O_CREAT | O_RDWR | O_TRUNC,
 			(S_IRUSR + S_IWUSR) | S_IRGRP | S_IROTH);
 	if (fd < 0 || close(fd) == -1)
 	{
 		perror(PROGRAM_NAME);
-		return (ft_free_and_null((void **)&(*io_red)->out_file), false);
+		return (ft_free_and_null((void **)&(*io_red)->in_file), false);
 	}
 	return (true);
 }
@@ -44,12 +44,12 @@ bool	exec_heredoc(int cmdtable_id, t_io_red **io_red)
 		{
 			ft_dprintf(STDERR_FILENO, ERROR_HEREDOC_UNEXPECTED_EOF,
 				PROGRAM_NAME, (*io_red)->here_end);
-			return (remove_file((*io_red)->out_file), true);
+			return (remove_file((*io_red)->in_file), true);
 		}
 		if (ft_strcmp(line, (*io_red)->here_end) == 0)
 			break ;
-		if (!append_line_to_file(line, (*io_red)->out_file))
-			return (remove_file((*io_red)->out_file), free(line), false);
+		if (!append_line_to_file(line, (*io_red)->in_file))
+			return (remove_file((*io_red)->in_file), free(line), false);
 		free(line);
 	}
 	free(line);

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -14,3 +14,66 @@
 #include "utils.h"
 #include "clean.h"
 
+bool	handle_red_in(t_final_cmd_table *final_cmd_table, char *filename)
+{
+	int	fd;
+
+	// printf("handle_red_in filename: %s\n", filename);
+	fd = open(filename, O_RDONLY);
+	if (fd < 0)
+	{
+		// printf("filename: %s\n", filename);
+		perror(PROGRAM_NAME);
+		return (false);
+	}
+	replace_fd(&fd, &final_cmd_table->read_fd);
+	return (true);
+}
+
+bool	handle_red_out(
+	t_final_cmd_table *final_cmd_table, char *filename, int o_flags)
+{
+	int	fd;
+
+	// printf("handle_red_out filename: %s\n", filename);
+	fd = open(filename, o_flags, (S_IRUSR + S_IWUSR) | S_IRGRP | S_IROTH);
+	if (fd < 0)
+	{
+		// printf("filename: %s\n", filename);
+		perror(PROGRAM_NAME);
+		return (false);
+	}
+	replace_fd(&fd, &final_cmd_table->write_fd);
+	return (true);
+}
+
+bool	handle_redirect_by_type(
+	t_final_cmd_table *final_cmd_table, t_io_red *io_red)
+{
+	if (io_red->type == T_RED_IN || io_red->type == T_HERE_DOC)
+		return (handle_red_in(final_cmd_table, io_red->in_file));
+	else if (io_red->type == T_RED_OUT)
+		return (handle_red_out(
+				final_cmd_table, io_red->out_file, O_CREAT | O_RDWR | O_TRUNC));
+	else if (io_red->type == T_APPEND)
+		return (handle_red_out(
+				final_cmd_table,
+				io_red->out_file, O_CREAT | O_RDWR | O_APPEND));
+	return (true);
+}
+
+bool	handle_io_redirect(
+	t_final_cmd_table *final_cmd_table, t_list *io_red_node)
+{
+	while (io_red_node)
+	{
+		if (!handle_redirect_by_type(final_cmd_table, io_red_node->content))
+		{
+			// safe_close(&final_cmd_table->read_fd);
+			// safe_close(&final_cmd_table->write_fd);
+			return (false);
+		}
+		io_red_node = io_red_node->next;
+	}
+	return (true);
+}

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -18,12 +18,11 @@ bool	handle_red_in(t_final_cmd_table *final_cmd_table, char *filename)
 {
 	int	fd;
 
-	// printf("handle_red_in filename: %s\n", filename);
 	fd = open(filename, O_RDONLY);
 	if (fd < 0)
 	{
-		// printf("filename: %s\n", filename);
-		perror(PROGRAM_NAME);
+		ft_dprintf(2, "%s: %s: ", PROGRAM_NAME, filename);
+		perror("");
 		return (false);
 	}
 	replace_fd(&fd, &final_cmd_table->read_fd);
@@ -35,12 +34,11 @@ bool	handle_red_out(
 {
 	int	fd;
 
-	// printf("handle_red_out filename: %s\n", filename);
 	fd = open(filename, o_flags, (S_IRUSR + S_IWUSR) | S_IRGRP | S_IROTH);
 	if (fd < 0)
 	{
-		// printf("filename: %s\n", filename);
-		perror(PROGRAM_NAME);
+		ft_dprintf(2, "%s: %s: ", PROGRAM_NAME, filename);
+		perror("");
 		return (false);
 	}
 	replace_fd(&fd, &final_cmd_table->write_fd);

--- a/source/backend/redirection/pipe_redirect.c
+++ b/source/backend/redirection/pipe_redirect.c
@@ -20,7 +20,7 @@ void	safe_close_pipe(t_pipe *pipe)
 	safe_close(pipe->write_fd);
 }
 
-void	replace_pipe_end(int *from_end, int *to_end)
+void	replace_fd(int *from_end, int *to_end)
 {
 	if (*from_end == -1)
 		return ;
@@ -32,13 +32,13 @@ void	replace_pipe_end(int *from_end, int *to_end)
 void	handle_pipes_parent(t_pipe *new_pipe, t_pipe *old_pipe)
 {
 	safe_close(new_pipe->write_fd);
-	replace_pipe_end(new_pipe->read_fd, old_pipe->read_fd);
+	replace_fd(new_pipe->read_fd, old_pipe->read_fd);
 }
 
 void	handle_pipes_child(t_pipe *new_pipe, t_pipe *old_pipe)
 {
 	safe_close(new_pipe->read_fd);
-	replace_pipe_end(new_pipe->write_fd, old_pipe->write_fd);
+	replace_fd(new_pipe->write_fd, old_pipe->write_fd);
 }
 
 void	safe_close_all_pipes(t_shell *shell)

--- a/source/debug/print_final_cmd_table.c
+++ b/source/debug/print_final_cmd_table.c
@@ -45,6 +45,9 @@ void	print_final_cmd_table(t_final_cmd_table *final_cmd_table)
 {
 	printf("\n\n========= final cmd table =========\n");
 	print_simple_cmd_array(final_cmd_table->simple_cmd);
+	printf("exec_path: %s\n", final_cmd_table->exec_path);
+	printf("read_fd: %d\n", final_cmd_table->read_fd);
+	printf("write_fd: %d\n", final_cmd_table->write_fd);
 	print_assignment_array(final_cmd_table->assignment_array);
 	printf("===================================\n\n");
 }

--- a/source/init_shell.c
+++ b/source/init_shell.c
@@ -84,6 +84,7 @@ bool	ft_init_shell(t_shell *shell, char **env)
 	init_pipe(&shell->new_pipe);
 	shell->exit_status = 0;
 	shell->exit_code = EXIT_SUCCESS;
+	shell->child_pid_list = NULL;
 	shell->env_list = NULL;
 	shell->token_list = NULL;
 	// shell->ast = NULL;

--- a/source/main.c
+++ b/source/main.c
@@ -62,7 +62,6 @@ bool	ft_read_input(t_shell *shell)
 	line = readline(PROMPT);
 	if (!line)
 		return (false);
-	printf("haha123\n");
 	shell->input_line = line;
 	add_history(shell->input_line);
 	return (true);

--- a/source/main.c
+++ b/source/main.c
@@ -62,6 +62,7 @@ bool	ft_read_input(t_shell *shell)
 	line = readline(PROMPT);
 	if (!line)
 		return (false);
+	printf("haha123\n");
 	shell->input_line = line;
 	add_history(shell->input_line);
 	return (true);

--- a/source/shell_clean.c
+++ b/source/shell_clean.c
@@ -25,6 +25,7 @@ void	free_env_node(t_env *env)
 
 void	ft_clean_shell(t_shell *shell)
 {
+	ft_lstclear(&shell->child_pid_list, free);
 	ft_lstclear(&shell->env_list, (void *)free_env_node);
 	ft_lstclear(&shell->token_list, (void *)free_token_node);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);

--- a/source/utils/cmd_table_operation_utils.c
+++ b/source/utils/cmd_table_operation_utils.c
@@ -30,6 +30,8 @@ t_cmd_table	*init_cmd_table(void)
 		return (NULL);
 	cmd_table->id = 0;
 	cmd_table->subshell_level = 0;
+	cmd_table->read_fd = -1;
+	cmd_table->write_fd = -1;
 	cmd_table->type = C_NONE;
 	cmd_table->assignment_list = NULL;
 	cmd_table->simple_cmd_list = NULL;

--- a/source/utils/cmd_table_status_utils.c
+++ b/source/utils/cmd_table_status_utils.c
@@ -29,3 +29,10 @@ t_cmd_table	*get_last_simple_cmd_table(t_list_d *cmd_table_list)
 	}
 	return (last_simple_cmd_table);
 }
+
+char	*get_cmd_name_from_list(t_list *simple_cmd_list)
+{
+	if (ft_lstsize_non_null(simple_cmd_list) == 0)
+		return (NULL);
+	return ((char *)simple_cmd_list->content);
+}

--- a/source/utils/final_cmd_table_utils.c
+++ b/source/utils/final_cmd_table_utils.c
@@ -117,23 +117,24 @@ bool	setup_fd(
 	{
 		if (!handle_io_redirect(final_cmd_table, cmd_table->io_red_list))
 		{
-			shell->exit_code = IO_RED_ERROR;
+			shell->exit_code = GENERAL_ERROR;
 			return (false);
 		}
 	}
 	return (true);
 }
 
-bool	setup_final_cmd_table(
-	t_shell *shell, t_cmd_table *cmd_table, t_final_cmd_table *final_cmd_table)
+int	setup_final_cmd_table(
+	t_shell *shell, t_cmd_table *cmd_table, t_final_cmd_table **final_cmd_table)
 {
-	if (!setup_env(final_cmd_table, shell->env_list) || \
-		!setup_simple_cmd(final_cmd_table, cmd_table->simple_cmd_list) || \
-		!setup_exec_path(final_cmd_table) || \
-		!setup_fd(shell, final_cmd_table, cmd_table) || \
-		!setup_assignment_array(final_cmd_table, cmd_table->assignment_list))
-		return (false);
-	return (true);
+	if (!setup_env(*final_cmd_table, shell->env_list) || \
+		!setup_simple_cmd(*final_cmd_table, cmd_table->simple_cmd_list) || \
+		!setup_exec_path(*final_cmd_table) || \
+		!setup_assignment_array(*final_cmd_table, cmd_table->assignment_list))
+		return (free_final_cmd_table(final_cmd_table), SUBSHELL_ERROR);
+	if (!setup_fd(shell, *final_cmd_table, cmd_table))
+		return (free_final_cmd_table(final_cmd_table), GENERAL_ERROR);
+	return (SUCCESS);
 }
 
 void	free_final_cmd_table(t_final_cmd_table **final_cmd_table)
@@ -154,10 +155,8 @@ t_final_cmd_table	*get_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table)
 	final_cmd_table = ft_calloc(1, sizeof(t_final_cmd_table));
 	if (!final_cmd_table)
 		return (NULL);
-	if (!setup_final_cmd_table(shell, cmd_table, final_cmd_table))
-		return (free_final_cmd_table(&final_cmd_table), NULL);
-
-	// if (final_cmd_table->simple_cmd[0] == NULL && 
+	shell->exit_code = setup_final_cmd_table(shell, cmd_table, &final_cmd_table);
+	// if (final_cmd_table->simple_cmd[0] == NULL &&
 	// 	final_cmd_table->assignment_array)
 	// 	handle_assignment(shell, final_cmd_table);
 	return (final_cmd_table);

--- a/source/utils/final_cmd_table_utils.c
+++ b/source/utils/final_cmd_table_utils.c
@@ -15,25 +15,33 @@
 #include "utils.h"
 #include "debug.h"
 
-bool	setup_simple_cmd(
-			t_shell *shell,
-			t_final_cmd_table *final_cmd_table,
-			t_list *simple_cmd_list)
-{
-	int		ret;
-	t_list	*expanded_list;
+// bool	setup_simple_cmd(
+// 			t_shell *shell,
+// 			t_final_cmd_table *final_cmd_table,
+// 			t_list *simple_cmd_list)
+// {
+// 	int		ret;
+// 	t_list	*expanded_list;
 
-	final_cmd_table->simple_cmd = NULL;
-	if (!simple_cmd_list)
-		return (true);
-	expanded_list = NULL;
-	ret = expand_list(shell, simple_cmd_list, &expanded_list);
-	if (ret == SUBSHELL_ERROR)
-		return (ft_lstclear(&expanded_list, free), false);
-	else if (ret == BAD_SUBSTITUTION)
-		ft_lstclear(&expanded_list, free);
-	final_cmd_table->simple_cmd = convert_list_to_string_array(expanded_list);
-	ft_lstclear(&expanded_list, free);
+// 	final_cmd_table->simple_cmd = NULL;
+// 	if (!simple_cmd_list)
+// 		return (true);
+// 	expanded_list = NULL;
+// 	ret = expand_list(shell, simple_cmd_list, &expanded_list);
+// 	if (ret == SUBSHELL_ERROR)
+// 		return (ft_lstclear(&expanded_list, free), false);
+// 	else if (ret == BAD_SUBSTITUTION)
+// 		ft_lstclear(&expanded_list, free);
+// 	final_cmd_table->simple_cmd = convert_list_to_string_array(expanded_list);
+// 	ft_lstclear(&expanded_list, free);
+// 	if (!final_cmd_table->simple_cmd)
+// 		return (false);
+// 	return (true);
+// }
+
+bool	setup_simple_cmd(t_final_cmd_table *final_cmd_table, t_list *simple_cmd_list)
+{
+	final_cmd_table->simple_cmd = convert_list_to_string_array(simple_cmd_list);
 	if (!final_cmd_table->simple_cmd)
 		return (false);
 	return (true);
@@ -47,14 +55,14 @@ bool	setup_exec_path(t_final_cmd_table *final_cmd_table)
 		final_cmd_table->exec_path = NULL;
 		return (true);
 	}
-	final_cmd_table->exec_path = get_exec_path(final_cmd_table->simple_cmd[0],
-		final_cmd_table->envp);
+	final_cmd_table->exec_path = get_exec_path(
+			final_cmd_table->simple_cmd[0], final_cmd_table->envp);
 	if (!final_cmd_table->exec_path)
 		return (false);
 	return (true);
 }
 
-bool	setup_assignment(
+bool	setup_assignment_array(
 			t_final_cmd_table *final_cmd_table,
 			t_list *assignment_list)
 {
@@ -77,7 +85,7 @@ bool	setup_env(t_final_cmd_table *final_cmd_table, t_list *env_list)
 	final_cmd_table->envp = NULL;
 	if (!env_list)
 		return (true);
-	final_cmd_table->envp = (char **)malloc( \
+	final_cmd_table->envp = (char **)malloc(\
 								(ft_lstsize(env_list) + 1) * sizeof(char *));
 	if (!final_cmd_table->envp)
 		return (false);
@@ -85,7 +93,7 @@ bool	setup_env(t_final_cmd_table *final_cmd_table, t_list *env_list)
 	while (env_list)
 	{
 		env_node = (t_env *)env_list->content;
-		sprintf(tmp, "%s=%s", env_node->key, env_node->value);	// TODO: This is really dangerous, bc the user could set a very long key or value.
+		sprintf(tmp, "%s=%s", env_node->key, env_node->value); // TODO: This is really dangerous, bc the user could set a very long key or value.
 		final_cmd_table->envp[i] = ft_strdup(tmp);
 		if (!final_cmd_table->envp[i])
 			return (free_array(&final_cmd_table->envp), false);
@@ -96,42 +104,36 @@ bool	setup_env(t_final_cmd_table *final_cmd_table, t_list *env_list)
 	return (true);
 }
 
-bool	setup_fd(t_shell *shell, t_final_cmd_table *final_cmd_table, t_cmd_table *cmd_table)
+bool	setup_fd(
+	t_shell *shell, t_final_cmd_table *final_cmd_table, t_cmd_table *cmd_table)
 {
 	final_cmd_table->read_fd = STDIN_FILENO;
 	final_cmd_table->write_fd = STDOUT_FILENO;
-	// do pipe redirection
 	if (*shell->old_pipe.read_fd != -1)
 		final_cmd_table->read_fd = *shell->old_pipe.read_fd;
 	if (*shell->old_pipe.write_fd != -1)
 		final_cmd_table->write_fd = *shell->old_pipe.write_fd;
-
-	// printf("cmd: %s\n", final_cmd_table->simple_cmd[0]);
-	// printf("old_pipe read_fd: %d, write_fd: %d\n", *shell->old_pipe.read_fd, *shell->old_pipe.write_fd);
-	// printf("new_pipe read_fd: %d, write_fd: %d\n", *shell->new_pipe.read_fd, *shell->new_pipe.write_fd);
-	// printf("final_cmd_table read_fd: %d, write_fd: %d\n", final_cmd_table->read_fd, final_cmd_table->write_fd);
-	// do io redirection
-	(void)cmd_table;
+	if (ft_lstsize_non_null(cmd_table->io_red_list) > 0)
+	{
+		if (!handle_io_redirect(final_cmd_table, cmd_table->io_red_list))
+		{
+			shell->exit_code = IO_RED_ERROR;
+			return (false);
+		}
+	}
 	return (true);
 }
 
-t_final_cmd_table	*init_final_cmd_table(
-						t_shell *shell,
-						t_cmd_table *cmd_table)
+bool	setup_final_cmd_table(
+	t_shell *shell, t_cmd_table *cmd_table, t_final_cmd_table *final_cmd_table)
 {
-	t_final_cmd_table	*final_cmd_table;
-
-	final_cmd_table = ft_calloc(1, sizeof(t_final_cmd_table));
-	if (!final_cmd_table)
-		return (NULL);
 	if (!setup_env(final_cmd_table, shell->env_list) || \
-		!setup_simple_cmd(
-			shell, final_cmd_table, cmd_table->simple_cmd_list) || \
+		!setup_simple_cmd(final_cmd_table, cmd_table->simple_cmd_list) || \
 		!setup_exec_path(final_cmd_table) || \
 		!setup_fd(shell, final_cmd_table, cmd_table) || \
-		!setup_assignment(final_cmd_table, cmd_table->assignment_list))
-		return (free_final_cmd_table(&final_cmd_table), NULL);
-	return (final_cmd_table);
+		!setup_assignment_array(final_cmd_table, cmd_table->assignment_list))
+		return (false);
+	return (true);
 }
 
 void	free_final_cmd_table(t_final_cmd_table **final_cmd_table)
@@ -140,6 +142,8 @@ void	free_final_cmd_table(t_final_cmd_table **final_cmd_table)
 	free_array(&(*final_cmd_table)->simple_cmd);
 	free((*final_cmd_table)->exec_path);
 	free_array(&(*final_cmd_table)->assignment_array);
+	safe_close(&(*final_cmd_table)->read_fd);
+	safe_close(&(*final_cmd_table)->write_fd);
 	ft_free_and_null((void **)final_cmd_table);
 }
 
@@ -147,12 +151,14 @@ t_final_cmd_table	*get_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table)
 {
 	t_final_cmd_table	*final_cmd_table;
 
-	final_cmd_table = init_final_cmd_table(shell, cmd_table);
+	final_cmd_table = ft_calloc(1, sizeof(t_final_cmd_table));
 	if (!final_cmd_table)
 		return (NULL);
-	// TODO: expand assignment array
-	if (final_cmd_table->simple_cmd[0] == NULL && final_cmd_table->assignment_array)
-		handle_assignment(shell, final_cmd_table);
-	// do redirections
+	if (!setup_final_cmd_table(shell, cmd_table, final_cmd_table))
+		return (free_final_cmd_table(&final_cmd_table), NULL);
+
+	// if (final_cmd_table->simple_cmd[0] == NULL && 
+	// 	final_cmd_table->assignment_array)
+	// 	handle_assignment(shell, final_cmd_table);
 	return (final_cmd_table);
 }

--- a/source/utils/io_redirect_status_utils.c
+++ b/source/utils/io_redirect_status_utils.c
@@ -1,0 +1,12 @@
+#include "defines.h"
+#include "utils.h"
+
+int	get_redirect_type_from_list(t_list *io_red_list)
+{
+	t_io_red	*io_red;
+
+	if (!io_red_list)
+		return (T_NONE);
+	io_red = io_red_list->content;
+	return (io_red->type);
+}

--- a/source/utils/process_utils.c
+++ b/source/utils/process_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process_utils.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: codespace <codespace@student.42.fr>        +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/02 14:30:49 by lyeh              #+#    #+#             */
-/*   Updated: 2024/01/14 19:44:22 by codespace        ###   ########.fr       */
+/*   Updated: 2024/01/25 16:25:25 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,9 +26,8 @@ int	handle_exit_status(int wstatus)
 	return (UNEXPECT_EXIT);
 }
 
-void	wait_process(t_shell *shell, int pid)
+void	wait_process(t_shell *shell, pid_t pid)
 {
-	// printf("wait_process, exit_code: %d\n", shell->exit_code);
 	if (waitpid(pid, &shell->exit_status, 0) == -1)
 	{
 		shell->exit_code = UNEXPECT_EXIT;


### PR DESCRIPTION
Fix `cat | ls` behavior