### PR TITLE
[FIX] Wait for all children in pipeline to finish before exiting

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 15:56:26 by lyeh              #+#    #+#             */
-/*   Updated: 2024/01/18 23:46:08 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/01/25 16:24:17 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -277,13 +277,14 @@ new_pipe: read=fd, write=fd
 */
 typedef struct s_shell
 {
-	int				pid;
-	int				subshell_pid;
+	pid_t			pid;
+	pid_t			subshell_pid;
 	int				subshell_level;
 	t_pipe			old_pipe;
 	t_pipe			new_pipe;
 	int				exit_status;
 	int				exit_code;
+	t_list			*child_pid_list;
 	t_list			*env_list;
 	t_list			*token_list;
 	t_list_d		*cmd_table_list;

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/17 13:38:17 by lyeh              #+#    #+#             */
-/*   Updated: 2024/01/23 03:33:57 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/01/25 16:25:19 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,7 @@ char		**convert_list_to_string_array(t_list *list);
 char		**append_string_array(char **array, char *str);
 
 /* Process utils */
-void		wait_process(t_shell *shell, int pid);
+void		wait_process(t_shell *shell, pid_t pid);
 int			status(int wstatus);
 
 /* Type utils */

--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/16 13:33:38 by ldulling          #+#    #+#              #
-#    Updated: 2024/01/18 01:54:20 by ldulling         ###   ########.fr        #
+#    Updated: 2024/01/25 16:11:32 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -68,6 +68,7 @@ TMP		+=	$(addprefix $(DIR)$(SUBDIR), \
 			ft_lstmap.c \
 			ft_lstnew.c \
 			ft_lstnew_back.c \
+			ft_lstnew_front.c \
 			ft_lstpop_front.c \
 			ft_lstpop_front_content.c \
 			ft_lstsize.c \

--- a/libraries/libft/inc/libft.h
+++ b/libraries/libft/inc/libft.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/24 16:17:46 by ldulling          #+#    #+#             */
-/*   Updated: 2024/01/18 01:54:09 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/01/25 16:11:26 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -70,6 +70,7 @@ t_list		*ft_lstlast(t_list *lst);
 t_list		*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *));
 t_list		*ft_lstnew(void *content);
 bool		ft_lstnew_back(t_list **lst, void *content);
+bool		ft_lstnew_front(t_list **lst, void *content);
 t_list		*ft_lstpop_front(t_list **lst);
 void		*ft_lstpop_front_content(t_list **lst);
 int			ft_lstsize(t_list *lst);

--- a/libraries/libft/src/libft/lists/singly_linked/ft_lstnew_front.c
+++ b/libraries/libft/src/libft/lists/singly_linked/ft_lstnew_front.c
@@ -1,0 +1,35 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_lstnew_front.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/01/25 16:09:14 by ldulling          #+#    #+#             */
+/*   Updated: 2024/01/25 16:09:17 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+/**
+ * The ft_lstnew_front function creates a new node with the provided content and
+ * adds it to the beginning of the singly linked list.
+ *
+ * @param lst     The address of the list to add the new node to.
+ * @param content The content to be added to the new node.
+ *
+ * @return        Returns true if the new node was successfully added, false if
+ *                malloc failed.
+ *
+ */
+bool	ft_lstnew_front(t_list **lst, void *content)
+{
+	t_list	*new_node;
+
+	new_node = ft_lstnew(content);
+	if (new_node == NULL)
+		return (false);
+	ft_lstadd_front(lst, new_node);
+	return (true);
+}

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -55,19 +55,21 @@ bool	pre_expand_simple_cmd(t_shell *shell, t_list_d *cmd_table_node)
 	t_list		*expanded_list;
 	int			ret;
 
-	expanded_list = NULL;
 	while (cmd_table_node)
 	{
-		cmd_table = cmd_table_node->content;
-		if (!cmd_table->simple_cmd_list)
-			return (true);
-		ret = expand_list(shell, cmd_table->simple_cmd_list, &expanded_list);
-		if (ret == SUBSHELL_ERROR)
-			return (ft_lstclear(&expanded_list, free), false);
-		else if (ret == BAD_SUBSTITUTION)
-			ft_lstclear(&expanded_list, free);
-		ft_lstclear(&cmd_table->simple_cmd_list, free);
-		cmd_table->simple_cmd_list = expanded_list;
+		expanded_list = NULL;
+		if (get_cmd_table_type_from_list(cmd_table_node) == C_SIMPLE_CMD)
+		{
+			cmd_table = cmd_table_node->content;
+			ret = expand_list(
+					shell, cmd_table->simple_cmd_list, &expanded_list);
+			if (ret == SUBSHELL_ERROR)
+				return (ft_lstclear(&expanded_list, free), false);
+			else if (ret == BAD_SUBSTITUTION)
+				ft_lstclear(&expanded_list, free);
+			ft_lstclear(&cmd_table->simple_cmd_list, free);
+			cmd_table->simple_cmd_list = expanded_list;
+		}
 		cmd_table_node = cmd_table_node->next;
 	}
 	return (true);

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -3,20 +3,6 @@
 #include "clean.h"
 #include "debug.h"
 
-void	bind_io_and_exec_external(
-	t_shell *shell, t_final_cmd_table *final_cmd_table)
-{
-	if (!redirect_io(shell, final_cmd_table))
-	{
-		free_final_cmd_table(&final_cmd_table);
-		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
-	}
-	execve(final_cmd_table->exec_path, final_cmd_table->simple_cmd,
-		final_cmd_table->envp);
-	free_final_cmd_table(&final_cmd_table);
-	ft_clean_and_exit_shell(shell, CMD_EXEC_FAILED, "execve failed");
-}
-
 void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 {
 	t_final_cmd_table	*final_cmd_table;

--- a/source/init_shell.c
+++ b/source/init_shell.c
@@ -84,6 +84,7 @@ bool	ft_init_shell(t_shell *shell, char **env)
 	init_pipe(&shell->new_pipe);
 	shell->exit_status = 0;
 	shell->exit_code = EXIT_SUCCESS;
+	shell->child_pid_list = NULL;
 	shell->env_list = NULL;
 	shell->token_list = NULL;
 	// shell->ast = NULL;

--- a/source/shell_clean.c
+++ b/source/shell_clean.c
@@ -25,6 +25,7 @@ void	free_env_node(t_env *env)
 
 void	ft_clean_shell(t_shell *shell)
 {
+	ft_lstclear(&shell->child_pid_list, free);
 	ft_lstclear(&shell->env_list, (void *)free_env_node);
 	ft_lstclear(&shell->token_list, (void *)free_token_node);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);

--- a/source/utils/process_utils.c
+++ b/source/utils/process_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process_utils.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: codespace <codespace@student.42.fr>        +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/02 14:30:49 by lyeh              #+#    #+#             */
-/*   Updated: 2024/01/14 19:44:22 by codespace        ###   ########.fr       */
+/*   Updated: 2024/01/25 16:25:25 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,9 +26,8 @@ int	handle_exit_status(int wstatus)
 	return (UNEXPECT_EXIT);
 }
 
-void	wait_process(t_shell *shell, int pid)
+void	wait_process(t_shell *shell, pid_t pid)
 {
-	// printf("wait_process, exit_code: %d\n", shell->exit_code);
 	if (waitpid(pid, &shell->exit_status, 0) == -1)
 	{
 		shell->exit_code = UNEXPECT_EXIT;


### PR DESCRIPTION
Fix `cat | ls` behavior