### PR TITLE
[FIX] Hotfix pipe redirection bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ SPACE			:=	$() $()
 #	Valgrind
 
 VALGRINDIGNORE	:=	cat cp diff find git grep head ls make man mkdir mv ncdu \
-					norminette ps rm tail time top touch wc which
+					norminette ps rm tail time top touch wc which yes
 
 ABSOLUTE_PATHS	:=	$(foreach cmd,$(VALGRINDIGNORE),$(shell which $(cmd)))
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -52,7 +52,8 @@ void		move_past_pipeline(t_list_d **cmd_table_node);
 
 /* Final cmd table utils */
 void		free_final_cmd_table(t_final_cmd_table **final_cmd_table);
-bool		set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table);
+bool		set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table, \
+								bool is_setup_fd);
 
 /* Expansion utils */
 int			expand_list(t_shell *shell, t_list *list, t_list **expanded_list);

--- a/include/utils.h
+++ b/include/utils.h
@@ -51,9 +51,9 @@ void		move_past_subshell(t_list_d **cmd_table_node);
 void		move_past_pipeline(t_list_d **cmd_table_node);
 
 /* Final cmd table utils */
-void		free_final_cmd_table(t_final_cmd_table **final_cmd_table);
-bool		set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table, \
-								bool is_setup_fd);
+void		free_final_cmd_table(
+				t_final_cmd_table **final_cmd_table, bool close_fd);
+bool		set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table);
 
 /* Expansion utils */
 int			expand_list(t_shell *shell, t_list *list, t_list **expanded_list);

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -22,7 +22,7 @@ void	handle_cmd_execution(t_shell *shell, t_list_d **cmd_table_node)
 	t_cmd_table	*cmd_table;
 
 	cmd_table = (*cmd_table_node)->content;
-	if (!set_final_cmd_table(shell, cmd_table))
+	if (!set_final_cmd_table(shell, cmd_table, false))
 	{
 		raise_error_to_own_subprocess(shell, MALLOC_ERROR, "malloc failed");
 		move_past_pipeline(cmd_table_node);

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -28,7 +28,7 @@ void	handle_cmd_execution(t_shell *shell, t_list_d **cmd_table_node)
 		move_past_pipeline(cmd_table_node);
 		return ;
 	}
-	if (is_builtin(get_cmd_name_from_list(cmd_table->simple_cmd_list)) && \
+	if (is_builtin(shell->final_cmd_table->simple_cmd[0]) && \
 		!is_scmd_in_pipeline(*cmd_table_node))
 		handle_builtin(shell, cmd_table_node);
 	else

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -22,7 +22,7 @@ void	handle_cmd_execution(t_shell *shell, t_list_d **cmd_table_node)
 	t_cmd_table	*cmd_table;
 
 	cmd_table = (*cmd_table_node)->content;
-	if (!set_final_cmd_table(shell, cmd_table, false))
+	if (!set_final_cmd_table(shell, cmd_table))
 	{
 		raise_error_to_own_subprocess(shell, MALLOC_ERROR, "malloc failed");
 		move_past_pipeline(cmd_table_node);

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -46,6 +46,7 @@ void	safe_redirect_io_and_exec_builtin(t_shell *shell)
 	int					ret;
 
 	final_cmd_table = shell->final_cmd_table;
+	// print_final_cmd_table(final_cmd_table);
 	ret = SUCCESS;
 	if (ft_strcmp(final_cmd_table->simple_cmd[0], "exit") != 0)
 	{

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -36,7 +36,7 @@ void	exec_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 {
 	t_cmd_table	*cmd_table;
 
-	if (!set_final_cmd_table(shell, (*cmd_table_node)->content, true))
+	if (!set_final_cmd_table(shell, (*cmd_table_node)->content))
 		return (raise_error_to_own_subprocess(
 				shell, MALLOC_ERROR, "malloc failed"));
 	cmd_table = get_cmd_table_from_list(*cmd_table_node);

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -36,7 +36,7 @@ void	exec_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 {
 	t_cmd_table	*cmd_table;
 
-	if (!set_final_cmd_table(shell, (*cmd_table_node)->content))
+	if (!set_final_cmd_table(shell, (*cmd_table_node)->content, true))
 		return (raise_error_to_own_subprocess(
 				shell, MALLOC_ERROR, "malloc failed"));
 	cmd_table = get_cmd_table_from_list(*cmd_table_node);

--- a/source/shell_clean.c
+++ b/source/shell_clean.c
@@ -30,7 +30,7 @@ void	ft_clean_shell(t_shell *shell)
 	ft_lstclear(&shell->env_list, (void *)free_env_node);
 	ft_lstclear(&shell->token_list, (void *)free_token_node);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);
-	free_final_cmd_table(&shell->final_cmd_table);
+	free_final_cmd_table(&shell->final_cmd_table, true);
 	// free_ast_node(shell->ast);
 }
 
@@ -42,7 +42,7 @@ void	reset_submodule_variable(t_shell *shell)
 	ft_lstclear(&shell->token_list, (void *)free_token_node);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);
 	ft_free_and_null((void **)&shell->input_line);
-	free_final_cmd_table(&shell->final_cmd_table);
+	free_final_cmd_table(&shell->final_cmd_table, true);
 }
 
 void	ft_clean_and_exit_shell(t_shell *shell, int exit_code, char *msg)

--- a/source/utils/final_cmd_table_utils.c
+++ b/source/utils/final_cmd_table_utils.c
@@ -112,7 +112,7 @@ void	setup_fd(
 		final_cmd_table->write_fd = *shell->old_pipe.write_fd;
 }
 
-void	free_final_cmd_table(t_final_cmd_table **final_cmd_table)
+void	free_final_cmd_table(t_final_cmd_table **final_cmd_table, bool close_fd)
 {
 	if (!final_cmd_table || !*final_cmd_table)
 		return ;
@@ -120,14 +120,17 @@ void	free_final_cmd_table(t_final_cmd_table **final_cmd_table)
 	free_array(&(*final_cmd_table)->simple_cmd);
 	free((*final_cmd_table)->exec_path);
 	free_array(&(*final_cmd_table)->assignment_array);
-	safe_close(&(*final_cmd_table)->read_fd);
-	safe_close(&(*final_cmd_table)->write_fd);
+	if (close_fd)
+	{
+		safe_close(&(*final_cmd_table)->read_fd);
+		safe_close(&(*final_cmd_table)->write_fd);
+	}
 	ft_free_and_null((void **)final_cmd_table);
 }
 
-bool	set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table, bool is_setup_fd)
+bool	set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table)
 {
-	free_final_cmd_table(&shell->final_cmd_table);
+	free_final_cmd_table(&shell->final_cmd_table, false);
 	shell->final_cmd_table = ft_calloc(1, sizeof(t_final_cmd_table));
 	if (!shell->final_cmd_table || \
 		!setup_env(shell->final_cmd_table, shell->env_list) || \
@@ -136,7 +139,6 @@ bool	set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table, bool is_setup_f
 		!setup_assignment_array(
 			shell->final_cmd_table, cmd_table->assignment_list))
 		return (false);
-	if (is_setup_fd)
-		setup_fd(shell, shell->final_cmd_table);
+	setup_fd(shell, shell->final_cmd_table);
 	return (true);
 }

--- a/source/utils/final_cmd_table_utils.c
+++ b/source/utils/final_cmd_table_utils.c
@@ -125,7 +125,7 @@ void	free_final_cmd_table(t_final_cmd_table **final_cmd_table)
 	ft_free_and_null((void **)final_cmd_table);
 }
 
-bool	set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table)
+bool	set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table, bool is_setup_fd)
 {
 	free_final_cmd_table(&shell->final_cmd_table);
 	shell->final_cmd_table = ft_calloc(1, sizeof(t_final_cmd_table));
@@ -136,6 +136,7 @@ bool	set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table)
 		!setup_assignment_array(
 			shell->final_cmd_table, cmd_table->assignment_list))
 		return (false);
-	setup_fd(shell, shell->final_cmd_table);
+	if (is_setup_fd)
+		setup_fd(shell, shell->final_cmd_table);
 	return (true);
 }


### PR DESCRIPTION
The preferred solution will be that the `final_cmd_table` only ever gets created once per `cmd_table`.

For now, the hotfix just says that `setup_fd()` should only be called in `exec_simple_cmd()` , not in `handle_cmd_execution()`.

* Also resolves #138 