### PR TITLE
[FIX] Protect if PARSING_TABLE macro is not defined

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -44,6 +44,10 @@
 #  define EXIT_STR			"exit"
 # endif
 
+# ifndef PARSING_TABLE
+#  define PARSING_TABLE		0
+# endif
+
 // # define PROGRAM_NAME       "🌊rash"
 // # define PROGRAM_NAME       "minishell: "
 # define PROGRAM_NAME       "\e[1;34m🌊rash\e[0m"

--- a/include/defines.h
+++ b/include/defines.h
@@ -45,7 +45,9 @@
 # endif
 
 # ifndef PARSING_TABLE
-#  define PARSING_TABLE		0
+#  define DEFINITIONS_OK	false
+# else
+#  define DEFINITIONS_OK	true
 # endif
 
 // # define PROGRAM_NAME       "🌊rash"

--- a/source/main.c
+++ b/source/main.c
@@ -29,7 +29,7 @@ int	main(int argc, char **argv, char **env)
 	t_shell	shell;
 
 	((void)argc, (void)argv);
-	if (!ft_init_shell(&shell, env))
+	if (!PARSING_TABLE || !ft_init_shell(&shell, env))
 		raise_error_and_escape(&shell, "init shell failed");
 	while (true)
 	{

--- a/source/main.c
+++ b/source/main.c
@@ -29,7 +29,7 @@ int	main(int argc, char **argv, char **env)
 	t_shell	shell;
 
 	((void)argc, (void)argv);
-	if (!PARSING_TABLE || !ft_init_shell(&shell, env))
+	if (!DEFINITIONS_OK || !ft_init_shell(&shell, env))
 		raise_error_and_escape(&shell, "init shell failed");
 	while (true)
 	{


### PR DESCRIPTION
In such a case, init it to `0`, and check before initializing the shell if `PARSING_TABLE` is not `0`.