### PR TITLE
[FIX] Handle non-existing PATH env variable for getting the exec path

### DIFF
--- a/include/cd.h
+++ b/include/cd.h
@@ -49,7 +49,7 @@ bool		is_dot_cmpnt(char *dir);
 
 /* environment_utils.c */
 t_env		*find_env_node(t_list *env_list, char *key, char *value);
-char		*get_value_from_env(t_list *env_list, char *key);
+char		*get_value_from_env_list(t_list *env_list, char *key);
 void		remove_env_node(t_list **env_list, char *key, char *value);
 char		*replace_env_value(t_list *env_list, char *key, char *value);
 

--- a/source/backend/executor/executor_utils.c
+++ b/source/backend/executor/executor_utils.c
@@ -79,11 +79,35 @@ bool	set_all_path(char ***all_path, char **envp)
 	return (true);
 }
 
+char	*find_exec_path(char **all_path, char *cmd_name)
+{
+	char	*exec_path;
+	int		exec_path_len;
+	int		cmd_name_len;
+	int		i;
+
+	cmd_name_len = ft_strlen(cmd_name);
+	i = 0;
+	while (all_path[i])
+	{
+		exec_path_len = ft_strlen(all_path[i]) + 1 + cmd_name_len;
+		exec_path = (char *)malloc(exec_path_len + 1);
+		if (!exec_path)
+			return (NULL);
+		ft_snprintf(exec_path, exec_path_len + 1, "%s/%s",
+			all_path[i], cmd_name);
+		if (access(exec_path, F_OK) == 0)
+			return (exec_path);
+		free(exec_path);
+		i++;
+	}
+	return (ft_strdup(cmd_name));
+}
+
 char	*get_exec_path(char *cmd_name, char **envp)
 {
-	char	exec_path[PATH_MAX];
+	char	*exec_path;
 	char	**all_path;
-	int		i;
 
 	if (ft_strchr(cmd_name, '/'))
 		return (ft_strdup(cmd_name));
@@ -91,17 +115,8 @@ char	*get_exec_path(char *cmd_name, char **envp)
 		return (NULL);
 	if (!all_path)
 		return (ft_strdup(cmd_name));
-	i = 0;
-	while (all_path[i])
-	{
-		ft_snprintf(exec_path, PATH_MAX, "%s/%s", all_path[i], cmd_name);
-		if (access(exec_path, F_OK) == 0)
-			break ;
-		i++;
-	}
-	if (i == get_array_len(all_path))
-		return (free_array(&all_path), ft_strdup(cmd_name));
-	return (free_array(&all_path), ft_strdup(exec_path));
+	exec_path = find_exec_path(all_path, cmd_name);
+	return (free_array(&all_path), exec_path);
 }
 
 // char	*get_exec_path(char *cmd_name, char **envp)

--- a/source/builtins/cd/environment_utils.c
+++ b/source/builtins/cd/environment_utils.c
@@ -40,8 +40,8 @@ t_env	*find_env_node(t_list *env_list, char *key, char *value)
 	return (NULL);
 }
 
-// TODO: Almost the same function as get_replacement() from expander
-char	*get_value_from_env(t_list *env_list, char *key)
+// TODO: Almost the same function as get_replacement() from expander and get_value_from_env() from executor_utils
+char	*get_value_from_env_list(t_list *env_list, char *key)
 {
 	t_env	*env_node;
 	char	*value;

--- a/source/builtins/cd/get_target_dir.c
+++ b/source/builtins/cd/get_target_dir.c
@@ -24,13 +24,13 @@ char	*get_target_dir(char **args, t_list *env_list)
 	}
 	if (!args[1])
 	{
-		target_dir = get_value_from_env(env_list, "HOME");
+		target_dir = get_value_from_env_list(env_list, "HOME");
 		if (!target_dir)
 			return (ft_dprintf(2, ERROR_CD_HOME_NOT_SET, PROGRAM_NAME), NULL);
 	}
 	else if (ft_strcmp(args[1], "-") == 0)
 	{
-		target_dir = get_value_from_env(env_list, "OLDPWD");
+		target_dir = get_value_from_env_list(env_list, "OLDPWD");
 		if (!target_dir)
 			return (ft_dprintf(2, ERROR_CD_OLDPWD_NOT_SET, PROGRAM_NAME), NULL);
 	}


### PR DESCRIPTION
If `PATH` is `NULL` or doesn't exist, try to find the executable in the current directory.

Also:
* Change `extract_env()` to `get_value_with_key()` and remove unnecessary malloc from it.
  Also fix differentiation between, for example, `AA` and `AAA` env variables by checking if a '=' is after the key.