### PR TITLE
[FEAT] Implement export without arguments -> print out the exported environment

### DIFF
--- a/include/builtins.h
+++ b/include/builtins.h
@@ -28,6 +28,7 @@ int		ft_exec_echo(char *args[]);
 int		ft_exec_pwd(void);
 void	exec_exit(t_shell *shell, char *args[]);
 int		exec_cd(char *args[], t_list **env_list);
+int		exec_export(char *args[], t_list **env_list);
 
 int		get_args_error(char *args[]);
 

--- a/include/defines.h
+++ b/include/defines.h
@@ -118,6 +118,9 @@
 # define OPENING_BRACE		'{'
 # define CLOSING_BRACE		'}'
 
+/* Export */
+# define EXPORT_PREFIX		"export "
+
 /* Error Messages */
 // TODO Add minishell name in the front of messages
 # define ERROR_PARSER_SYNTAX				\
@@ -136,6 +139,8 @@
 "%s: cd: HOME not set\n"
 # define ERROR_CD_OLDPWD_NOT_SET			\
 "%s: cd: OLDPWD not set\n"
+# define ERROR_EXPORT_INVALID_IDENTIFIER	\
+"%s: export: `%s': not a valid identifier\n"
 // TODO: Replace with OS error message
 # define ERROR_REMOVE_FILE					\
 "%s: warning: failed to remove file `%s'\n"

--- a/include/export.h
+++ b/include/export.h
@@ -1,0 +1,15 @@
+#ifndef EXPORT_H
+# define EXPORT_H
+
+# include "defines.h"
+
+/* print_exported_env.c */
+int		print_exported_env(t_list *env_list);
+int		get_total_export_printout_len(t_list *env_list,
+			int prefix_len, int format_len);
+int		get_env_str_len(t_env *env_node, int prefix_len, int format_len);
+void	fill_export_printout(t_list *env_list, char *export_printout,
+			int prefix_len, int format_len);
+t_env	*get_next_env_node(t_list *env_list, char *prev_key);
+
+#endif

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -34,7 +34,8 @@ void	exec_builtin_cmd(t_shell *shell)
 		shell->exit_code = exec_cd(final_cmd_table->simple_cmd,
 				&shell->env_list);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "export") == 0)
-		shell->exit_code = 123;
+		shell->exit_code = exec_export(final_cmd_table->simple_cmd,
+				&shell->env_list);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "exit") == 0)
 		exec_exit(shell, final_cmd_table->simple_cmd);
 }

--- a/source/builtins/export/export.c
+++ b/source/builtins/export/export.c
@@ -1,0 +1,21 @@
+#include "export.h"
+#include "utils.h"
+
+/* string_utils.c */
+// is_valid_varname()
+// is_valid_varname_start()
+
+/* setup_env_list.c */
+// bool	process_env_str_to_env_list(char *env_str, t_list **env_list)
+
+// void	handle_invalid_identifier(char *arg, int *ret)
+// {
+
+// }
+
+int	exec_export(char *args[], t_list **env_list)
+{
+	if (get_array_len(args) < 2)
+		return (print_exported_env(*env_list));
+	return (SUCCESS);
+}

--- a/source/builtins/export/print_exported_env.c
+++ b/source/builtins/export/print_exported_env.c
@@ -19,7 +19,7 @@ int	print_exported_env(t_list *env_list)
 	format_len = ft_strlen("=\"\"\n");
 	total_len = get_total_export_printout_len(env_list, prefix_len, format_len);
 	if (total_len == 0)
-		return (printf("\n"), SUCCESS);
+		return (SUCCESS);
 	export_printout = (char *)malloc(total_len + 1);
 	if (!export_printout)
 		return (SUBSHELL_ERROR);

--- a/source/builtins/export/print_exported_env.c
+++ b/source/builtins/export/print_exported_env.c
@@ -1,0 +1,106 @@
+#include "export.h"
+#include "utils.h"
+
+// Print all exported env vars in ASCII order, with "export " prepended.
+// The value gets put in double-quotes.
+// TODO: Quotes, dollar signs, backslash and '`' are escaped with a backslash.
+
+// Get the total length of everything that will have to be printed.
+// Malloc once, then use ft_snprintf to fill.
+// Then print once.
+int	print_exported_env(t_list *env_list)
+{
+	char	*export_printout;
+	int		format_len;
+	int		prefix_len;
+	int		total_len;
+
+	prefix_len = ft_strlen(EXPORT_PREFIX);
+	format_len = ft_strlen("=\"\"\n");
+	total_len = get_total_export_printout_len(env_list, prefix_len, format_len);
+	if (total_len == 0)
+		return (printf("\n"), SUCCESS);
+	export_printout = (char *)malloc(total_len + 1);
+	if (!export_printout)
+		return (SUBSHELL_ERROR);
+	fill_export_printout(env_list, export_printout, prefix_len, format_len);
+	printf("%s", export_printout);
+	free(export_printout);
+	return (SUCCESS);
+}
+
+int	get_total_export_printout_len(
+	t_list *env_list, int prefix_len, int format_len)
+{
+	t_env	*env_node;
+	int		total_len;
+
+	total_len = 0;
+	while (env_list)
+	{
+		env_node = env_list->content;
+		if (env_node->export == X_EXPORT_YES)
+			total_len += get_env_str_len(env_node, prefix_len, format_len);
+		env_list = env_list->next;
+	}
+	return (total_len);
+}
+
+int	get_env_str_len(t_env *env_node, int prefix_len, int format_len)
+{
+	int	len;
+
+	len = prefix_len + ft_strlen(env_node->key);
+	if (env_node->value)
+		len += ft_strlen(env_node->value) + format_len;
+	else
+		len += 1;
+	return (len);
+}
+
+void	fill_export_printout(
+		t_list *env_list, char *export_printout, int prefix_len, int format_len)
+{
+	t_env	*env_node;
+	int		i;
+	int		size;
+
+	i = 0;
+	env_node = get_next_env_node(env_list, NULL);
+	while (env_node)
+	{
+		if (env_node->export == X_EXPORT_YES)
+		{
+			size = prefix_len + ft_strlen(env_node->key);
+			i += ft_snprintf(&export_printout[i], size + 1, "%s%s",
+					EXPORT_PREFIX, env_node->key);
+			if (env_node->value)
+			{
+				size = ft_strlen(env_node->value) + format_len;
+				i += ft_snprintf(&export_printout[i], size + 1, "=\"%s\"\n",
+						env_node->value);
+			}
+			else
+				i += ft_snprintf(&export_printout[i], 2, "\n");
+		}
+		env_node = get_next_env_node(env_list, env_node->key);
+	}
+}
+
+t_env	*get_next_env_node(t_list *env_list, char *prev_key)
+{
+	t_env	*env_node;
+	t_env	*next_node;
+
+	next_node = NULL;
+	while (env_list)
+	{
+		env_node = env_list->content;
+		if (env_node->export == X_EXPORT_YES && \
+			(!prev_key || ft_strcmp(env_node->key, prev_key) > 0) && \
+			(!next_node || ft_strcmp(env_node->key, next_node->key) < 0))
+			next_node = env_node;
+		env_list = env_list->next;
+	}
+	return (next_node);
+}


### PR DESCRIPTION
- [x] First merge #164
---

- If no arguments, print all exported environment variables ordered by ASCII value, with `export ` prepended.
- If the variable has a value, an `=` gets printed after the variable name and the value gets put in double-quotes.

### Question:
- [ ] In bash, double-quotes `"`, dollar signs `$`, backslashes `\` and backticks ``` ` ``` are escaped with a backslash.
  **Example:** 
  ```sh
  bash-5.1$ export VAR='"'
  bash-5.1$ export
  export VAR="\""
  ```
  How should we handle this?
  This is how it looks for us atm:
  ```sh
  export VAR="""
  ```