### PR TITLE
[FEAT] Implement full export with arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,3 @@ dkms.conf
 .vscode/
 minishell
 .VSCodeCounter/
-todo

--- a/include/export.h
+++ b/include/export.h
@@ -3,6 +3,11 @@
 
 # include "defines.h"
 
+/* export.c */
+
+bool	handle_var_export(char *str, t_list **env_list);
+void	change_export_flag(t_list *env_list, char *key, t_export export);
+
 /* print_exported_env.c */
 int		print_exported_env(t_list *env_list);
 int		get_total_export_printout_len(t_list *env_list,

--- a/include/init.h
+++ b/include/init.h
@@ -6,5 +6,6 @@
 bool	init_shell(t_shell *shell);
 bool	setup_env_list(t_shell *shell);
 bool	setup_default_env_list(t_shell *shell);
+bool	check_special_env_vars(t_list **env_list);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -113,7 +113,8 @@ bool		drop_num_stack(t_list **stack, int num, void (*del)(void *));
 t_list		*pop_num_stack(t_list **stack, int num);
 
 /* String utils */
-bool		is_valid_varname(char c);
+bool		is_valid_varname(char *str);
+bool		is_valid_varname_char(char c);
 bool		is_valid_varname_start(char c);
 bool		skip_to_same_quote(char *str, size_t *i);
 bool		replace_string_content(char **str, char *new_content);

--- a/include/utils.h
+++ b/include/utils.h
@@ -56,17 +56,20 @@ void		free_final_cmd_table(
 bool		set_final_cmd_table(t_shell *shell, t_cmd_table *cmd_table);
 
 /* Environment utils */
+bool		extract_env_key(char **res, const char *str);
+bool		extract_env_value(char **res, const char *str);
 char		*get_value_from_env(char *env[], char *key);
 bool		is_key_in_env(char *env[], char *key);
 
 bool		append_env_node(
 				t_list **env_list, char *key, char *value, t_export export);
-bool		is_key_in_env_list(t_list *env_list, char *key);
-
 t_env		*find_env_node(t_list *env_list, char *key, char *value);
 char		*get_value_from_env_list(t_list *env_list, char *key);
+bool		is_key_in_env_list(t_list *env_list, char *key);
+bool		process_str_to_env_list(
+				char *str, t_list **env_list, t_export export);
 void		remove_env_node(t_list **env_list, char *key, char *value);
-char		*replace_env_value(
+bool		replace_env_value(
 				t_list *env_list, char *key, char *value, char **old_value);
 
 /* Expansion utils */

--- a/source/builtins/export/export.c
+++ b/source/builtins/export/export.c
@@ -1,21 +1,68 @@
 #include "export.h"
 #include "utils.h"
 
-/* string_utils.c */
-// is_valid_varname()
-// is_valid_varname_start()
-
-/* setup_env_list.c */
-// bool	process_env_str_to_env_list(char *env_str, t_list **env_list)
-
-// void	handle_invalid_identifier(char *arg, int *ret)
-// {
-
-// }
-
 int	exec_export(char *args[], t_list **env_list)
 {
+	int	i;
+	int	ret;
+
 	if (get_array_len(args) < 2)
 		return (print_exported_env(*env_list));
-	return (SUCCESS);
+	ret = SUCCESS;
+	i = 1;
+	while (args[i])
+	{
+		if (!is_valid_varname(args[i]))
+		{
+			ft_dprintf(STDERR_FILENO, ERROR_EXPORT_INVALID_IDENTIFIER,
+				PROGRAM_NAME, args[i]);
+			ret = GENERAL_ERROR;
+		}
+		else if (!handle_var_export(args[i], env_list))
+			return (SUBSHELL_ERROR);
+		i++;
+	}
+	return (ret);
+}
+
+bool	handle_var_export(char *str, t_list **env_list)
+{
+	char	*key;
+	char	*old_value;
+	char	*value;
+
+	if (!extract_env_key(&key, str))
+		return (false);
+	if (is_key_in_env_list(*env_list, key))
+	{
+		if (!extract_env_value(&value, str))
+			return (free(key), false);
+		if (value && replace_env_value(*env_list, key, value, &old_value))
+			free(old_value);
+		change_export_flag(*env_list, key, X_EXPORT_YES);
+		free(key);
+	}
+	else
+	{
+		free(key);
+		if (!process_str_to_env_list(str, env_list, X_EXPORT_YES))
+			return (false);
+	}
+	return (true);
+}
+
+void	change_export_flag(t_list *env_list, char *key, t_export export)
+{
+	t_env	*env_node;
+
+	while (env_list)
+	{
+		env_node = env_list->content;
+		if (ft_strcmp(env_node->key, key) == 0)
+		{
+			env_node->export = export;
+			return ;
+		}
+		env_list = env_list->next;
+	}
 }

--- a/source/frontend/expander/bad_substitution.c
+++ b/source/frontend/expander/bad_substitution.c
@@ -22,7 +22,7 @@ bool	check_braces(char *str, size_t *i)
 		return (false);
 	(*i)++;
 	if (str[*i - 1] != '?')
-		while (is_valid_varname(str[*i]))
+		while (is_valid_varname_char(str[*i]))
 			(*i)++;
 	if (str[*i] == '?')
 		while (str[*i] && str[*i] != CLOSING_BRACE)

--- a/source/frontend/expander/expand_variable.c
+++ b/source/frontend/expander/expand_variable.c
@@ -46,7 +46,7 @@ size_t	count_var_len(char *str)
 			str++;
 	}
 	len = 0;
-	while (is_valid_varname(*str))
+	while (is_valid_varname_char(*str))
 	{
 		len++;
 		str++;

--- a/source/frontend/expander/expander_utils.c
+++ b/source/frontend/expander/expander_utils.c
@@ -44,7 +44,7 @@ size_t	count_replace_len(char *str)
 	else if (str[replace_len] == '?')
 		replace_len++;
 	else
-		while (is_valid_varname(str[replace_len]))
+		while (is_valid_varname_char(str[replace_len]))
 			replace_len++;
 	return (replace_len);
 }

--- a/source/frontend/lexer/set_token_type.c
+++ b/source/frontend/lexer/set_token_type.c
@@ -73,7 +73,7 @@ bool	is_assignment_word(char *str)
 	i = 0;
 	if (str && is_valid_varname_start(str[i]))
 	{
-		while (is_valid_varname(str[i]))
+		while (is_valid_varname_char(str[i]))
 			i++;
 		if (str[i] == '=')
 			return (true);

--- a/source/init/setup_env_list.c
+++ b/source/init/setup_env_list.c
@@ -1,55 +1,11 @@
 #include "init.h"
 #include "utils.h"
 
-static bool	extract_string(char **res, char *str, char *delim)
-{
-	char	*tmp;
-
-	tmp = ft_strtok(str, delim);
-	if (!tmp)
-		tmp = "";
-	*res = ft_strdup(tmp);
-	if (str)
-		str[ft_strlen(str)] = '=';
-	if (!*res)
-		return (false);
-	return (true);
-}
-
-/*
- * PWD should always be set by current shell.
- * If OLDPWD exists and its value is not a real directory,
- * delete OLDPWD entirely (permissions don't matter).
- */
-bool	process_env_str_to_env_list(char *env_str, t_list **env_list)
-{
-	char	*key;
-	char	*value;
-
-	if (!extract_string(&key, env_str, "="))
-		return (false);
-	if (ft_strcmp(key, "PWD") == 0)
-	{
-		value = getcwd(NULL, 0);
-		if (!value)
-			return (free(key), false);
-	}
-	else if (!extract_string(&value, NULL, ""))
-		return (free(key), false);
-	if (ft_strcmp(key, "OLDPWD") == 0 && !is_dir(value))
-	{
-		free(key);
-		free(value);
-	}
-	else if (!append_env_node(env_list, key, value, X_EXPORT_YES))
-		return (free(key), free(value), false);
-	return (true);
-}
-
 bool	setup_env_list(t_shell *shell)
 {
 	extern char	**environ;
-	int	i;
+	int			i;
+	t_list		*tmp_list;
 
 	if (!setup_default_env_list(shell))
 		return (false);
@@ -58,9 +14,36 @@ bool	setup_env_list(t_shell *shell)
 	i = 0;
 	while (environ[i])
 	{
-		if (!process_env_str_to_env_list(environ[i], &shell->env_list))
+		tmp_list = NULL;
+		if (!process_str_to_env_list(environ[i], &tmp_list, X_EXPORT_YES))
 			return (false);
+		if (!check_special_env_vars(&tmp_list))
+			return (ft_lstclear(&tmp_list, free), false);
+		ft_lstadd_back(&shell->env_list, tmp_list);
 		i++;
 	}
+	return (true);
+}
+
+/*
+ * PWD should always be set by current shell.
+ * If OLDPWD exists and its value is not a real directory,
+ * delete OLDPWD entirely (permissions don't matter).
+ */
+bool	check_special_env_vars(t_list **env_list)
+{
+	t_env	*env_node;
+
+	env_node = (*env_list)->content;
+	if (ft_strcmp(env_node->key, "PWD") == 0)
+	{
+		free(env_node->value);
+		env_node->value = getcwd(NULL, 0);
+		if (!env_node->value)
+			return (false);
+	}
+	else if (ft_strcmp(env_node->key, "OLDPWD") == 0 && \
+			env_node->value && !is_dir(env_node->value))
+		ft_lstclear(env_list, free);
 	return (true);
 }

--- a/source/utils/env_list_utils.c
+++ b/source/utils/env_list_utils.c
@@ -12,6 +12,7 @@
 
 #include "minishell.h"
 #include "clean.h"
+#include "utils.h"
 
 bool	append_env_node(
 	t_list **env_list, char *key, char *value, t_export export)
@@ -28,39 +29,6 @@ bool	append_env_node(
 	if (!ft_lstnew_back(env_list, env_node))
 		return (free(env_node), false);
 	return (true);
-}
-
-bool	is_exported_env_node(t_list *env_list, char *key)
-{
-	t_env	*env_node;
-
-	while (env_list)
-	{
-		env_node = env_list->content;
-		if (ft_strcmp(env_node->key, key) == 0 && \
-			env_node->export == X_EXPORT_YES)
-			return (true);
-		env_list = env_list->next;
-	}
-	return (false);
-}
-
-bool	is_key_in_env_list(t_list *env_list, char *key)
-{
-	t_list	*cur;
-	t_env	*env_node;
-
-	if (!env_list || !key)
-		return (false);
-	cur = env_list;
-	while (cur)
-	{
-		env_node = (t_env *)cur->content;
-		if (ft_strcmp(env_node->key, key) == 0)
-			return (true);
-		cur = cur->next;
-	}
-	return (false);
 }
 
 t_env	*find_env_node(t_list *env_list, char *key, char *value)
@@ -101,6 +69,53 @@ char	*get_value_from_env_list(t_list *env_list, char *key)
 		env_list = env_list->next;
 	}
 	return (NULL);
+}
+
+bool	is_exported_env_node(t_list *env_list, char *key)
+{
+	t_env	*env_node;
+
+	while (env_list)
+	{
+		env_node = env_list->content;
+		if (ft_strcmp(env_node->key, key) == 0 && \
+			env_node->export == X_EXPORT_YES)
+			return (true);
+		env_list = env_list->next;
+	}
+	return (false);
+}
+
+bool	is_key_in_env_list(t_list *env_list, char *key)
+{
+	t_list	*cur;
+	t_env	*env_node;
+
+	if (!env_list || !key)
+		return (false);
+	cur = env_list;
+	while (cur)
+	{
+		env_node = (t_env *)cur->content;
+		if (ft_strcmp(env_node->key, key) == 0)
+			return (true);
+		cur = cur->next;
+	}
+	return (false);
+}
+
+bool	process_str_to_env_list(char *str, t_list **env_list, t_export export)
+{
+	char	*key;
+	char	*value;
+
+	if (!extract_env_key(&key, str))
+		return (false);
+	if (!extract_env_value(&value, str))
+		return (free(key), false);
+	if (!append_env_node(env_list, key, value, export))
+		return (free(key), free(value), false);
+	return (true);
 }
 
 void	remove_env_node(t_list **env_list, char *key, char *value)

--- a/source/utils/env_utils.c
+++ b/source/utils/env_utils.c
@@ -1,6 +1,38 @@
 #include "defines.h"
 
-static char	*get_value_from_str(char *str, char *key)
+bool	extract_env_key(char **res, const char *str)
+{
+	char	*equal_sign;
+	int		res_len;
+
+	equal_sign = ft_strchr(str, '=');
+	if (equal_sign)
+		res_len = equal_sign - str;
+	else
+		res_len = ft_strlen(str);
+	*res = ft_substr(str, 0, res_len);
+	if (!*res)
+		return (false);
+	return (true);
+}
+
+bool	extract_env_value(char **res, const char *str)
+{
+	char	*equal_sign;
+
+	equal_sign = ft_strchr(str, '=');
+	if (!equal_sign)
+		*res = NULL;
+	else
+	{
+		*res = ft_strdup(equal_sign + 1);
+		if (!*res)
+			return (false);
+	}
+	return (true);
+}
+
+static char	*get_value_with_key(char *str, char *key)
 {
 	int		key_len;
 	char	*value;
@@ -27,7 +59,7 @@ char	*get_value_from_env(char *env[], char *key)
 	i = 0;
 	while (env[i])
 	{
-		value = get_value_from_str(env[i], key);
+		value = get_value_with_key(env[i], key);
 		if (value)
 			break ;
 		i++;

--- a/source/utils/string_utils.c
+++ b/source/utils/string_utils.c
@@ -26,13 +26,13 @@ bool	replace_string_content(char **str, char *new_content)
 
 bool	is_valid_varname(char *str)
 {
-	int i;
+	int	i;
 
 	i = 0;
 	if (!str || !is_valid_varname_start(str[i]))
 		return (false);
 	i++;
-	while (str[i])
+	while (str[i] && str[i] != '=')
 	{
 		if (!is_valid_varname_char(str[i]))
 			return (false);

--- a/source/utils/string_utils.c
+++ b/source/utils/string_utils.c
@@ -24,7 +24,24 @@ bool	replace_string_content(char **str, char *new_content)
 	return (true);
 }
 
-bool	is_valid_varname(char c)
+bool	is_valid_varname(char *str)
+{
+	int i;
+
+	i = 0;
+	if (!str || !is_valid_varname_start(str[i]))
+		return (false);
+	i++;
+	while (str[i])
+	{
+		if (!is_valid_varname_char(str[i]))
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
+bool	is_valid_varname_char(char c)
 {
 	return (ft_isalnum(c) || c == '_');
 }

--- a/todo
+++ b/todo
@@ -1,0 +1,22 @@
+# export:
+
+- [x] If args_len < 2, print all exported env vars in ASCII order, with "export " prepended.
+	- [x] The value gets put in double-quotes.
+	- [ ] Quotes, dollar signs, backslash and '`' are escaped with a backslash.
+
+- [x] If one of the variable assignments is not a valid variable name, return value will be GENERAL_ERROR (1), but export will still go through all arguments.
+The error message gets printed for every invalid identifier.
+
+- [x] If the argument string does not have an '=' and the key does not already exist, the value will be set to NULL.
+- [x] If the key already exists, the env_node will be set to be exported.
+
+### Error messages:
+- bash: export: `<invalid name>': not a valid identifier
+
+### Test cases:
+- [x] export "" -> export: `': not a valid identifier
+- [ ] export without any variable in env left -> just a newline.
+
+
+
+env -i /usr/bin/valgrind ./minishell


### PR DESCRIPTION
- [x] First merge #166 
---
- If one of the variable assignments is not a valid variable name, the return value will be GENERAL_ERROR (1), but export will still go through all arguments.
  The error message gets printed for every invalid identifier.
- If the key does not already exist, a new env_node with the key will be created and ...
  - if the argument string does not have an '=', the value will be set to NULL.
  - else, the value will be extracted from the argument string.
- If the key already exists and ...
  - if the argument string does have an '=', the value of the matching key will be replaced.
- In either case the env_node will be set to be exported.
