### PR TITLE
[FEAT] Implement unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ DEP_SUBDIRS		:=	$(sort $(dir $(DEP)))
 
 # ***************************** BUILD PROCESS ******************************** #
 
-.PHONY			:	all test run val valfd build lib clean fclean re
+.PHONY			:	all test run val noenv valfd build lib clean fclean re
 
 
 #	Compilation
@@ -139,6 +139,9 @@ run				:	all
 
 val				:	all
 					$(VALGRIND) $(VALGRINDFLAGS) "./$(NAME)"
+
+noenv			:	all
+					env -i $(VALGRIND) $(VALGRINDFLAGS) "./$(NAME)"
 
 valfd			:	all
 ifneq ($(TERMINAL),)

--- a/include/builtins.h
+++ b/include/builtins.h
@@ -29,6 +29,7 @@ int		ft_exec_pwd(void);
 void	exec_exit(t_shell *shell, char *args[]);
 int		exec_cd(char *args[], t_list **env_list);
 int		exec_export(char *args[], t_list **env_list);
+int		exec_unset(char *args[], t_list **env_list);
 
 int		get_args_error(char *args[]);
 

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -25,7 +25,8 @@ void	exec_builtin_cmd(t_shell *shell)
 	if (ft_strcmp(final_cmd_table->simple_cmd[0], "env") == 0)
 		shell->exit_code = ft_exec_env(final_cmd_table->env);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "unset") == 0)
-		shell->exit_code = 123;
+		shell->exit_code = exec_unset(final_cmd_table->simple_cmd,
+				&shell->env_list);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "echo") == 0)
 		shell->exit_code = ft_exec_echo(final_cmd_table->simple_cmd);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "pwd") == 0)

--- a/source/builtins/unset.c
+++ b/source/builtins/unset.c
@@ -1,0 +1,14 @@
+#include "utils.h"
+
+int	exec_unset(char *args[], t_list **env_list)
+{
+	int	i;
+
+	i = 1;
+	while (args[i])
+	{
+		remove_env_node(env_list, args[i], NULL);
+		i++;
+	}
+	return (SUCCESS);
+}


### PR DESCRIPTION
- [x] First merge #167 
---
- The function `remove_env_node()` was already implemented in this commit  [16731fa](https://github.com/LeaYeh/minishell/commit/16731fab3a64c38921f89b4fbb0a6382229a57d7#diff-34af145bb7235c58767c147eb40e76a9ad0cba08a045af75a9137ca4bc10e5cc) when implementing cd.
- Also add `noenv` goal to Makefile.
  It starts minishell with no environment (and with valgrind).