### PR TITLE
[FIX] Fix wrong token recognition of single `&`

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -111,7 +111,6 @@
 
 /* Lexer */
 # define QUOTES				"'\""
-# define TOK_SYMBOLS		"<>|&()"
 # define T_UNINITIALIZED	-1		//TODO Replace with Lea's UNDEFINED_TYPE -99
 
 /* Expander */

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -33,6 +33,7 @@ void	adjust_assignment_word_tokens(t_list *token_list);
 bool	ft_lexer(t_shell *shell);
 
 /* lexer_utils.c */
+bool	is_operator(char *token_data);
 void	print_missing_pair_error(char *str);
 void	skip_operator(char *token_data, size_t *i);
 bool	split_token_node(t_list *lst_node1, size_t i);

--- a/source/frontend/lexer/create_token_list.c
+++ b/source/frontend/lexer/create_token_list.c
@@ -51,7 +51,7 @@ bool	separate_operators(t_list *lst_node, size_t i)
 			skip_double_quote(token_data, &i);
 		else if (ft_strncmp(&token_data[i], DOLLAR_BRACE, 2) == 0)
 			skip_dollar_brace(token_data, &i, false);
-		else if (ft_strchr(TOK_SYMBOLS, token_data[i]))
+		else if (is_operator(&token_data[i]))
 		{
 			if (!split_and_advance_node(&lst_node, &token_data, &i))
 				return (false);

--- a/source/frontend/lexer/lexer_utils.c
+++ b/source/frontend/lexer/lexer_utils.c
@@ -12,6 +12,18 @@
 
 #include "utils.h"
 
+bool	is_operator(char *token_data)
+{
+	if (ft_strncmp(token_data, "&&", 2) == 0 || \
+		ft_strncmp(token_data, "|", 1) == 0 || \
+		ft_strncmp(token_data, "<", 1) == 0 || \
+		ft_strncmp(token_data, ">", 1) == 0 || \
+		ft_strncmp(token_data, "(", 1) == 0 || \
+		ft_strncmp(token_data, ")", 1) == 0)
+		return (true);
+	return (false);
+}
+
 void	print_missing_pair_error(char *str)
 {
 	char	missing_pair;


### PR DESCRIPTION
* ~~First solve #179~~
---
Test case:
```sh
echo &foo
```

Previously (wrong):
```sh
& foo
```
Fixed:
```sh
&foo
```