### PR TITLE
[FIX] Fix memory leaks when SIGPIPE occured in minishell child process

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,7 +14,7 @@ runs:
       shell: bash
     - run: |
         git clone https://github.com/LeaYeh/42_minishell_tester.git
-        cp -r 42_minishell_tester $HOME
+        mv 42_minishell_tester $HOME
         chmod +x $HOME/42_minishell_tester/tester.sh
         find .github/scripts -type f -name "*.sh" -exec chmod +x {} \;
         cp .github/scripts/*.sh $HOME

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,6 +8,10 @@ runs:
         sudo apt-get update
         sudo apt-get install -y build-essential clang-12 valgrind
       shell: bash
+    - run: bash --version
+      shell: bash
+    - run: valgrind --version
+      shell: bash
     - run: |
         git clone https://github.com/LeaYeh/42_minishell_tester.git
         cp -r 42_minishell_tester $HOME

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,11 @@ VALGRINDFLAGS	=	--errors-for-leak-kinds=all \
 
 VALGRINDFDFLAGS	:=	--track-fds=all
 
-VALGRINDIGNORE	:=	cat chmod cp diff find git grep head ls make man mkdir mv \
-					ncdu norminette ps rm sort tail time top touch wc which yes
+VALGRINDIGNORE	:=	norminette
 
-ABSOLUTE_PATHS	:=	$(foreach cmd,$(VALGRINDIGNORE),$(shell which $(cmd)))
+ABSOLUTE_PATHS	:=	/bin/* \
+					/usr/bin/* \
+					$(shell which -a $(VALGRINDIGNORE))
 
 
 #	Terminal

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ VALGRINDIGNORE	:=	norminette
 
 ABSOLUTE_PATHS	:=	/bin/* \
 					/usr/bin/* \
+					/usr/sbin/* \
 					$(shell which -a $(VALGRINDIGNORE))
 
 

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -25,6 +25,7 @@ void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 	setup_signal(shell, SIGQUIT, SIG_DEFAULT);
 	setup_signal(shell, SIGTERM, SIG_DEFAULT);
 	setup_signal(shell, SIGABRT, SIG_DEFAULT);
+	setup_signal(shell, SIGPIPE, SIG_DEFAULT);
 	execve(final_cmd_table->exec_path, final_cmd_table->simple_cmd,
 		final_cmd_table->env);
 	handle_exec_error(shell, final_cmd_table->exec_path);

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -25,7 +25,6 @@ void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 	setup_signal(shell, SIGQUIT, SIG_DEFAULT);
 	setup_signal(shell, SIGTERM, SIG_DEFAULT);
 	setup_signal(shell, SIGABRT, SIG_DEFAULT);
-	setup_signal(shell, SIGPIPE, SIG_DEFAULT);
 	execve(final_cmd_table->exec_path, final_cmd_table->simple_cmd,
 		final_cmd_table->env);
 	handle_exec_error(shell, final_cmd_table->exec_path);

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -57,6 +57,7 @@ void	handle_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 			shell, FORK_ERROR, "handle_simple_cmd fork failed");
 	else if (shell->subshell_pid == 0)
 	{
+		setup_signal(shell, SIGPIPE, SIG_IGNORE);
 		shell->subshell_level += 1;
 		handle_pipes_child(&shell->new_pipe, &shell->old_pipe);
 		exec_simple_cmd(shell, cmd_table_node);

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -41,7 +41,11 @@ void	exec_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 				shell, MALLOC_ERROR, "malloc failed"));
 	cmd_table = get_cmd_table_from_list(*cmd_table_node);
 	if (is_builtin(shell->final_cmd_table->simple_cmd[0]))
+	{
+		setup_signal(shell, SIGPIPE, SIG_IGNORE);
 		handle_builtin(shell, cmd_table_node);
+		setup_signal(shell, SIGPIPE, SIG_DEFAULT);
+	}
 	else
 		handle_external_cmd(shell, cmd_table);
 	ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
@@ -57,7 +61,6 @@ void	handle_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 			shell, FORK_ERROR, "handle_simple_cmd fork failed");
 	else if (shell->subshell_pid == 0)
 	{
-		setup_signal(shell, SIGPIPE, SIG_IGNORE);
 		shell->subshell_level += 1;
 		handle_pipes_child(&shell->new_pipe, &shell->old_pipe);
 		exec_simple_cmd(shell, cmd_table_node);

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -44,7 +44,6 @@ void	exec_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 	{
 		setup_signal(shell, SIGPIPE, SIG_IGNORE);
 		handle_builtin(shell, cmd_table_node);
-		setup_signal(shell, SIGPIPE, SIG_DEFAULT);
 	}
 	else
 		handle_external_cmd(shell, cmd_table);


### PR DESCRIPTION
If SIGPIPE would not get catched or ignored, the default behavior is to terminate the process. This would cause memory leaks for us, as in the example `echo 1 | >tmp_out`.

* Resolves [LEAK] `echo 1 | >tmp_out` leaks #179