### PR TITLE
[FIX] Stop full cmd list if received `Ctrl+C`

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -161,8 +161,8 @@ typedef enum e_state
 	SIG_DEFAULT		= 0,
 	SIG_IGNORE,
 	SIG_STANDARD,
-	SIG_HEREDOC,
-	SIG_SUBSHELL
+	SIG_RECORD,
+	SIG_HEREDOC
 }	t_state;
 
 typedef enum e_pt_col
@@ -374,6 +374,7 @@ typedef struct s_shell
 	pid_t				pid;
 	pid_t				subshell_pid;
 	int					subshell_level;
+	int					signal_record;
 	t_pipe				old_pipe;
 	t_pipe				new_pipe;
 	int					exit_code;

--- a/include/defines.h
+++ b/include/defines.h
@@ -159,7 +159,7 @@ typedef enum e_heredoc_status
 typedef enum e_state
 {
 	SIG_HEREDOC		= 0,
-	SIG_STD,
+	SIG_STANDARD,
 	SIG_SUBSHELL,
 	SIG_DEFAULT,
 	SIG_IGNORE

--- a/include/defines.h
+++ b/include/defines.h
@@ -158,11 +158,11 @@ typedef enum e_heredoc_status
 
 typedef enum e_state
 {
-	SIG_HEREDOC		= 0,
+	SIG_DEFAULT		= 0,
+	SIG_IGNORE,
 	SIG_STANDARD,
-	SIG_SUBSHELL,
-	SIG_DEFAULT,
-	SIG_IGNORE
+	SIG_HEREDOC,
+	SIG_SUBSHELL
 }	t_state;
 
 typedef enum e_pt_col

--- a/include/signals.h
+++ b/include/signals.h
@@ -7,6 +7,7 @@
 
 
 void	handle_signal_std(int signo, siginfo_t *info, void *context);
+void	handle_signal_record(int signo, siginfo_t *info, void *context);
 void	handle_signal_heredoc(int signo, siginfo_t *info, void *context);
 void	setup_signal(t_shell *shell, int signo, t_state state);
 // void	handle_sigint_enf_of_pipeline(t_shell *shell);

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -62,7 +62,7 @@ void	ft_executor(t_shell *shell)
 
 	setup_signal(shell, SIGINT, SIG_HEREDOC);
 	heredoc_status = ft_heredoc(shell);
-	setup_signal(shell, SIGINT, SIG_STD);
+	setup_signal(shell, SIGINT, SIG_STANDARD);
 	if (heredoc_status == HEREDOC_ERROR)
 		ft_clean_and_exit_shell(shell, MALLOC_ERROR, "heredoc malloc/fd error");
 	else if (heredoc_status == HEREDOC_ABORT)

--- a/source/backend/executor/handle_control_op.c
+++ b/source/backend/executor/handle_control_op.c
@@ -18,8 +18,12 @@
 
 bool	should_execute_next_pipeline(t_shell *shell, int type)
 {
-	if (shell->signal_record == SIGINT || \
-		shell->exit_code == TERM_BY_SIGNAL + SIGINT)
+	if (shell->signal_record != 0)
+	{
+		shell->exit_code = TERM_BY_SIGNAL + shell->signal_record;
+		return (false);
+	}
+	if (shell->exit_code == TERM_BY_SIGNAL + SIGINT)
 		return (false);
 	if (type == C_AND && shell->exit_code == 0)
 		return (true);

--- a/source/backend/executor/handle_control_op.c
+++ b/source/backend/executor/handle_control_op.c
@@ -16,13 +16,14 @@
 #include "utils.h"
 #include "clean.h"
 
-bool	should_execute_next_pipeline(int type, int exit_code)
+bool	should_execute_next_pipeline(t_shell *shell, int type)
 {
-	if (exit_code == TERM_BY_SIGNAL + SIGINT)
+	if (shell->signal_record == SIGINT || \
+		shell->exit_code == TERM_BY_SIGNAL + SIGINT)
 		return (false);
-	if (type == C_AND && exit_code == 0)
+	if (type == C_AND && shell->exit_code == 0)
 		return (true);
-	else if (type == C_OR && exit_code != 0)
+	else if (type == C_OR && shell->exit_code != 0)
 		return (true);
 	return (false);
 }
@@ -35,7 +36,7 @@ void	handle_and_or_op(t_shell *shell, t_list_d **cmd_table_node)
 		wait_process(shell, shell->subshell_pid);
 	cmd_table = (*cmd_table_node)->content;
 	*cmd_table_node = (*cmd_table_node)->next;
-	if (!should_execute_next_pipeline(cmd_table->type, shell->exit_code))
+	if (!should_execute_next_pipeline(shell, cmd_table->type))
 		move_past_pipeline(cmd_table_node);
 }
 

--- a/source/backend/executor/handle_pipeline.c
+++ b/source/backend/executor/handle_pipeline.c
@@ -89,7 +89,11 @@ void	handle_end_of_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 		safe_close_all_pipes(shell);
 		wait_process(shell, shell->subshell_pid);
 		if (shell->subshell_level != 0)
+		{
+			if (shell->signal_record != 0)
+				shell->exit_code = TERM_BY_SIGNAL + shell->signal_record;
 			ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
+		}
 	}
 }
 

--- a/source/backend/executor/handle_pipeline.c
+++ b/source/backend/executor/handle_pipeline.c
@@ -105,7 +105,7 @@ void	handle_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 	}
 	else if (shell->subshell_pid == 0)
 	{
-		setup_signal(shell, SIGTERM, SIG_STD);
+		setup_signal(shell, SIGTERM, SIG_STANDARD);
 		shell->subshell_level += 1;
 		// do T0
 		handle_pipes_child(&shell->new_pipe, &shell->old_pipe);
@@ -116,6 +116,6 @@ void	handle_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 		move_past_pipeline(cmd_table_node);
 		handle_end_of_pipeline(shell, cmd_table_node);
 		shell->subshell_pid = -1;
-		setup_signal(shell, SIGINT, SIG_STD);
+		setup_signal(shell, SIGINT, SIG_STANDARD);
 	}
 }

--- a/source/backend/executor/handle_pipeline.c
+++ b/source/backend/executor/handle_pipeline.c
@@ -95,7 +95,6 @@ void	handle_end_of_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 
 void	handle_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 {
-	setup_signal(shell, SIGINT, SIG_IGNORE);
 	shell->subshell_pid = fork();
 	if (shell->subshell_pid == -1)
 	{
@@ -105,6 +104,7 @@ void	handle_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 	}
 	else if (shell->subshell_pid == 0)
 	{
+		setup_signal(shell, SIGINT, SIG_IGNORE);
 		setup_signal(shell, SIGTERM, SIG_STANDARD);
 		shell->subshell_level += 1;
 		// do T0
@@ -113,6 +113,7 @@ void	handle_pipeline(t_shell *shell, t_list_d **cmd_table_node)
 	}
 	else
 	{
+		setup_signal(shell, SIGINT, SIG_RECORD);
 		move_past_pipeline(cmd_table_node);
 		handle_end_of_pipeline(shell, cmd_table_node);
 		shell->subshell_pid = -1;

--- a/source/init/init_shell.c
+++ b/source/init/init_shell.c
@@ -33,9 +33,9 @@ bool	init_shell(t_shell *shell)
 		return (false);
 	handle_signal_std(0, NULL, shell);
 	handle_signal_heredoc(0, NULL, shell);
-	setup_signal(shell, SIGINT, SIG_STD);
-	setup_signal(shell, SIGABRT, SIG_STD);
-	setup_signal(shell, SIGTERM, SIG_STD);
+	setup_signal(shell, SIGINT, SIG_STANDARD);
+	setup_signal(shell, SIGABRT, SIG_STANDARD);
+	setup_signal(shell, SIGTERM, SIG_STANDARD);
 	setup_signal(shell, SIGQUIT, SIG_IGNORE);
 	return (true);
 }

--- a/source/init/init_shell.c
+++ b/source/init/init_shell.c
@@ -19,6 +19,7 @@ bool	init_shell(t_shell *shell)
 	shell->pid = getpid();
 	shell->subshell_pid = -1;
 	shell->subshell_level = 0;
+	shell->signal_record = 0;
 	init_pipe(&shell->old_pipe);
 	init_pipe(&shell->new_pipe);
 	shell->exit_code = EXIT_SUCCESS;
@@ -32,6 +33,7 @@ bool	init_shell(t_shell *shell)
 	if (!setup_env_list(shell))
 		return (false);
 	handle_signal_std(0, NULL, shell);
+	handle_signal_record(0, NULL, shell);
 	handle_signal_heredoc(0, NULL, shell);
 	setup_signal(shell, SIGINT, SIG_STANDARD);
 	setup_signal(shell, SIGABRT, SIG_STANDARD);

--- a/source/shell_clean.c
+++ b/source/shell_clean.c
@@ -39,6 +39,7 @@ void	reset_submodule_variable(t_shell *shell)
 {
 	shell->subshell_level = 0;
 	shell->subshell_pid = -1;
+	shell->signal_record = 0;
 	ft_lstclear(&shell->child_pid_list, NULL);
 	ft_lstclear(&shell->token_list, (void *)free_token_node);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);

--- a/source/signal/signal.c
+++ b/source/signal/signal.c
@@ -78,6 +78,19 @@ void	handle_signal_std(int signo, siginfo_t *info, void *context)
 		ft_clean_and_exit_shell(shell, shell->exit_code, NULL);
 }
 
+void	handle_signal_record(int signo, siginfo_t *info, void *context)
+{
+	static t_shell	*shell;
+
+	(void)info;
+	if (!shell)
+	{
+		shell = context;
+		return ;
+	}
+	shell->signal_record = signo;
+}
+
 void	handle_signal_heredoc(int signo, siginfo_t *info, void *context)
 {
 	static t_shell	*shell;
@@ -110,6 +123,8 @@ void	setup_signal(t_shell *shell, int signo, t_state state)
 		sa.sa_handler = SIG_IGN;
 	else if (state == SIG_STANDARD)
 		sa.sa_sigaction = handle_signal_std;
+	else if (state == SIG_RECORD)
+		sa.sa_sigaction = handle_signal_record;
 	else if (state == SIG_HEREDOC)
 		sa.sa_sigaction = handle_signal_heredoc;
 	if (sigaction(signo, &sa, NULL) != 0)

--- a/source/signal/signal.c
+++ b/source/signal/signal.c
@@ -12,8 +12,8 @@ void	raise_error_to_all_subprocess(t_shell *shell, int exit_code, char *msg)
 	shell->exit_code = exit_code;
 	if (msg)
 		printf(STY_RED"%s: error: %s\n"STY_RES, PROGRAM_NAME, msg);
-	setup_signal(shell, SIGINT, SIG_STD);
-	setup_signal(shell, SIGABRT, SIG_STD);
+	setup_signal(shell, SIGINT, SIG_STANDARD);
+	setup_signal(shell, SIGABRT, SIG_STANDARD);
 	setup_signal(shell, SIGQUIT, SIG_IGNORE);
 	kill(-shell->pid, SIGTERM);
 }
@@ -43,9 +43,9 @@ void	raise_error_to_own_subprocess(t_shell *shell, int exit_code, char *msg)
 	shell->exit_code = exit_code;
 	if (msg)
 		printf(STY_RED"%s: error: %s\n"STY_RES, PROGRAM_NAME, msg);
-	setup_signal(shell, SIGINT, SIG_STD);
-	setup_signal(shell, SIGABRT, SIG_STD);
-	setup_signal(shell, SIGTERM, SIG_STD);
+	setup_signal(shell, SIGINT, SIG_STANDARD);
+	setup_signal(shell, SIGABRT, SIG_STANDARD);
+	setup_signal(shell, SIGTERM, SIG_STANDARD);
 	setup_signal(shell, SIGQUIT, SIG_IGNORE);
 	signal_to_all_subprocess(shell, SIGTERM);
 	kill(getpid(), SIGTERM);
@@ -106,7 +106,7 @@ void	setup_signal(t_shell *shell, int signo, t_state state)
 	sa.sa_flags = SA_RESTART | SA_SIGINFO;
 	if (state == SIG_HEREDOC)
 		sa.sa_sigaction = handle_signal_heredoc;
-	else if (state == SIG_STD)
+	else if (state == SIG_STANDARD)
 		sa.sa_sigaction = handle_signal_std;
 	else if (state == SIG_DEFAULT)
 		sa.sa_handler = SIG_DFL;

--- a/source/signal/signal.c
+++ b/source/signal/signal.c
@@ -104,14 +104,14 @@ void	setup_signal(t_shell *shell, int signo, t_state state)
 	if (sigemptyset(&sa.sa_mask) == -1)
 		ft_clean_and_exit_shell(shell, PREPROCESS_ERROR, "sigemptyset failed");
 	sa.sa_flags = SA_RESTART | SA_SIGINFO;
-	if (state == SIG_HEREDOC)
-		sa.sa_sigaction = handle_signal_heredoc;
-	else if (state == SIG_STANDARD)
-		sa.sa_sigaction = handle_signal_std;
-	else if (state == SIG_DEFAULT)
+	if (state == SIG_DEFAULT)
 		sa.sa_handler = SIG_DFL;
 	else if (state == SIG_IGNORE)
 		sa.sa_handler = SIG_IGN;
+	else if (state == SIG_STANDARD)
+		sa.sa_sigaction = handle_signal_std;
+	else if (state == SIG_HEREDOC)
+		sa.sa_sigaction = handle_signal_heredoc;
 	if (sigaction(signo, &sa, NULL) != 0)
 		perror("The signal is not supported:");
 }


### PR DESCRIPTION
Test case:
```sh
cat | ls && echo 123
```
~~Working behavior, but wrong exit code:~~ **SOLVED**
```sh
(cat | ls) && echo 123
```
---
- [ ] Wrong exit code: 0 instead of 130 (but this is weird for the user, bc `cat | ls` exits with 0)
```sh
echo 123 && cat | ls
```
---
- [ ] Wrong behavior with `SIGQUIT`: #206 
```sh
(cat | ls) && echo 123
```