### PR TITLE
[FIX] Clean readline history when exiting shell

### DIFF
--- a/source/shell_clean.c
+++ b/source/shell_clean.c
@@ -31,6 +31,7 @@ void	ft_clean_shell(t_shell *shell)
 	ft_lstclear(&shell->token_list, (void *)free_token_node);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);
 	free_final_cmd_table(&shell->final_cmd_table, true);
+	rl_clear_history();
 	// free_ast_node(shell->ast);
 }
 


### PR DESCRIPTION
When the process terminates, the operating system will reclaim all the memory allocated by the program, including the memory used by readline's history entries. So, from a memory leak perspective within the context of the program's lifetime, not calling rl_clear_history() before exiting won't cause a leak.