### PR TITLE
[FIX] Fix order of redirections for subshells

### DIFF
--- a/include/executor.h
+++ b/include/executor.h
@@ -32,6 +32,7 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node);
 bool	restore_std_io(int saved_std_io[2]);
 bool	save_std_io(int saved_std_io[2]);
 bool	redirect_scmd_io(t_shell *shell, int *read_fd, int *write_fd);
+bool	redirect_subshell_io(t_cmd_table *cmd_table);
 bool	handle_io_redirect(int *read_fd, int *write_fd, t_list *io_red_list);
 
 /* Redirection - Pipe */

--- a/include/executor.h
+++ b/include/executor.h
@@ -31,9 +31,8 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node);
 /* Redirection */
 bool	restore_std_io(int saved_std_io[2]);
 bool	save_std_io(int saved_std_io[2]);
-bool	redirect_io(t_shell *shell);
-bool	handle_io_redirect(
-			t_final_cmd_table *final_cmd_table, t_list *io_red_node);
+bool	redirect_scmd_io(t_shell *shell, int *read_fd, int *write_fd);
+bool	handle_io_redirect(int *read_fd, int *write_fd, t_list *io_red_list);
 
 /* Redirection - Pipe */
 bool	need_pipe(t_list_d *cmd_table_node);

--- a/include/utils.h
+++ b/include/utils.h
@@ -36,12 +36,13 @@ int			get_redirect_type_from_list(t_list *io_red_list);
 /* Cmd table utils */
 t_cmd_table	*init_cmd_table(void);
 void		free_cmd_table(t_cmd_table *cmd_table);
-t_cmd_table	*get_last_simple_cmd_table(t_list_d *cmd_table_list);
 bool		append_empty_cmd_table(t_list_d **cmd_table_list);
 bool		append_cmd_table_by_scenario(
 				int token_type, t_list_d **cmd_table_list);
 t_cmd_table	*get_cmd_table_from_list(t_list_d *cmd_table_node);
 int			get_cmd_table_type_from_list(t_list_d *cmd_table_list);
+t_cmd_table	*get_last_simple_cmd_table(t_list_d *cmd_table_list);
+t_cmd_table	*get_subshell_start(t_list_d *cmd_table_node);
 char		*get_cmd_name_from_list(t_list *simple_cmd_list);
 bool		is_control_op_cmd_table(int cmd_table_type);
 bool		is_builtin(char *cmd_name);

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -53,7 +53,8 @@ void	safe_redirect_io_and_exec_builtin(t_shell *shell)
 	if (ft_strcmp(final_cmd_table->simple_cmd[0], "exit") != 0)
 	{
 		if (!save_std_io(saved_std_io) || \
-			!redirect_io(shell))
+			!redirect_scmd_io(shell, &final_cmd_table->read_fd,
+				&final_cmd_table->write_fd))
 			ret = SUBSHELL_ERROR;
 		else
 			exec_builtin_cmd(shell);
@@ -73,7 +74,8 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 	t_cmd_table	*cmd_table;
 
 	cmd_table = (*cmd_table_node)->content;
-	if (!handle_io_redirect(shell->final_cmd_table, cmd_table->io_red_list))
+	if (!handle_io_redirect(&shell->final_cmd_table->read_fd,
+			&shell->final_cmd_table->write_fd, cmd_table->io_red_list))
 	{
 		if (shell->subshell_level != 0)
 			ft_clean_and_exit_shell(shell, GENERAL_ERROR, NULL);
@@ -88,7 +90,8 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 		safe_redirect_io_and_exec_builtin(shell);
 	else
 	{
-		if (!redirect_io(shell))
+		if (!redirect_scmd_io(shell, &shell->final_cmd_table->read_fd,
+				&shell->final_cmd_table->write_fd))
 			return (raise_error_to_own_subprocess(
 					shell, CREATE_FD_ERROR, "fd bind failed"));
 		exec_builtin_cmd(shell);

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -12,14 +12,16 @@ void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 	t_final_cmd_table	*final_cmd_table;
 
 	final_cmd_table = shell->final_cmd_table;
-	if (!handle_io_redirect(final_cmd_table, cmd_table->io_red_list))
+	if (!handle_io_redirect(&final_cmd_table->read_fd,
+			&final_cmd_table->write_fd, cmd_table->io_red_list))
 		ft_clean_and_exit_shell(shell, GENERAL_ERROR, NULL);
 	if (!shell->final_cmd_table->simple_cmd[0])
 		ft_clean_and_exit_shell(shell, SUCCESS, NULL);
 	if (!check_execfile_exist(final_cmd_table->exec_path,
 			final_cmd_table->simple_cmd[0]))
 		ft_clean_and_exit_shell(shell, CMD_NOT_FOUND, NULL);
-	if (!redirect_io(shell))
+	if (!redirect_scmd_io(shell, &final_cmd_table->read_fd,
+			&final_cmd_table->write_fd))
 		ft_clean_and_exit_shell(shell, GENERAL_ERROR, NULL);
 	setup_signal(shell, SIGINT, SIG_DEFAULT);
 	setup_signal(shell, SIGQUIT, SIG_DEFAULT);

--- a/source/backend/executor/handle_subshell.c
+++ b/source/backend/executor/handle_subshell.c
@@ -26,6 +26,9 @@ void	handle_subshell(t_shell *shell, t_list_d **cmd_table_node)
 	{
 		shell->subshell_level += 1;
 		handle_pipes_child(&shell->new_pipe, &shell->old_pipe);
+		if (!redirect_subshell_io(get_cmd_table_from_list(*cmd_table_node)))
+			ft_clean_and_exit_shell(
+				shell, CREATE_FD_ERROR, "subshell redirect failed");
 		*cmd_table_node = (*cmd_table_node)->next;
 		handle_process(shell, *cmd_table_node);
 	}

--- a/source/backend/redirection/bind.c
+++ b/source/backend/redirection/bind.c
@@ -16,15 +16,13 @@ bool	save_std_io(int saved_std_io[2])
 	return (true);
 }
 
-bool	redirect_io(t_shell *shell)
+bool	redirect_scmd_io(t_shell *shell, int *read_fd, int *write_fd)
 {
-	bool				ret;
-	t_final_cmd_table	*final_cmd_table;
+	bool	ret;
 
-	final_cmd_table = shell->final_cmd_table;
 	ret = true;
-	if (dup2(final_cmd_table->read_fd, STDIN_FILENO) == -1 || \
-		dup2(final_cmd_table->write_fd, STDOUT_FILENO) == -1)
+	if (dup2(*read_fd, STDIN_FILENO) == -1 || \
+		dup2(*write_fd, STDOUT_FILENO) == -1)
 	{
 		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
 		perror(NULL);
@@ -33,8 +31,8 @@ bool	redirect_io(t_shell *shell)
 	if (shell->subshell_level != 0)
 	{
 		safe_close_all_pipes(shell);
-		safe_close(&final_cmd_table->read_fd);
-		safe_close(&final_cmd_table->write_fd);
+		safe_close(read_fd);
+		safe_close(write_fd);
 	}
 	return (ret);
 }

--- a/source/backend/redirection/bind.c
+++ b/source/backend/redirection/bind.c
@@ -37,6 +37,29 @@ bool	redirect_scmd_io(t_shell *shell, int *read_fd, int *write_fd)
 	return (ret);
 }
 
+bool	redirect_subshell_io(t_cmd_table *cmd_table)
+{
+	int		read_fd;
+	int		write_fd;
+	bool	ret;
+
+	ret = true;
+	read_fd = -1;
+	write_fd = -1;
+	if (!handle_io_redirect(&read_fd, &write_fd, cmd_table->io_red_list))
+		ret = false;
+	else if ((read_fd != -1 && dup2(read_fd, STDIN_FILENO) == -1) || \
+		(write_fd != -1 && dup2(write_fd, STDOUT_FILENO) == -1))
+	{
+		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		perror(NULL);
+		ret = false;
+	}
+	safe_close(&read_fd);
+	safe_close(&write_fd);
+	return (ret);
+}
+
 bool	restore_std_io(int saved_std_io[2])
 {
 	bool	error;

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -14,7 +14,7 @@
 #include "utils.h"
 #include "clean.h"
 
-bool	handle_red_in(t_final_cmd_table *final_cmd_table, char *filename)
+bool	handle_red_in(int *read_fd, char *filename)
 {
 	int	fd;
 
@@ -25,12 +25,11 @@ bool	handle_red_in(t_final_cmd_table *final_cmd_table, char *filename)
 		perror("");
 		return (false);
 	}
-	replace_fd(&fd, &final_cmd_table->read_fd);
+	replace_fd(&fd, read_fd);
 	return (true);
 }
 
-bool	handle_red_out(
-	t_final_cmd_table *final_cmd_table, char *filename, int o_flags)
+bool	handle_red_out(int *write_fd, char *filename, int o_flags)
 {
 	int	fd;
 
@@ -41,39 +40,36 @@ bool	handle_red_out(
 		perror("");
 		return (false);
 	}
-	replace_fd(&fd, &final_cmd_table->write_fd);
+	replace_fd(&fd, write_fd);
 	return (true);
 }
 
-bool	handle_redirect_by_type(
-	t_final_cmd_table *final_cmd_table, t_io_red *io_red)
+bool	handle_redirect_by_type(int *read_fd, int *write_fd, t_io_red *io_red)
 {
 	if (io_red->type == T_RED_IN || io_red->type == T_HERE_DOC)
-		return (handle_red_in(final_cmd_table, io_red->in_file));
+		return (handle_red_in(read_fd, io_red->in_file));
 	else if (io_red->type == T_RED_OUT)
-		return (handle_red_out(
-				final_cmd_table, io_red->out_file, O_CREAT | O_RDWR | O_TRUNC));
+		return (handle_red_out(write_fd,
+				io_red->out_file, O_CREAT | O_RDWR | O_TRUNC));
 	else if (io_red->type == T_APPEND)
-		return (handle_red_out(
-				final_cmd_table,
+		return (handle_red_out(write_fd,
 				io_red->out_file, O_CREAT | O_RDWR | O_APPEND));
 	return (true);
 }
 
-bool	handle_io_redirect(
-	t_final_cmd_table *final_cmd_table, t_list *io_red_node)
+bool	handle_io_redirect(int *read_fd, int *write_fd, t_list *io_red_list)
 {
-	if (ft_lstsize_non_null(io_red_node) == 0)
+	if (ft_lstsize_non_null(io_red_list) == 0)
 		return (true);
-	while (io_red_node)
+	while (io_red_list)
 	{
-		if (!handle_redirect_by_type(final_cmd_table, io_red_node->content))
+		if (!handle_redirect_by_type(read_fd, write_fd, io_red_list->content))
 		{
-			// safe_close(&final_cmd_table->read_fd);
-			// safe_close(&final_cmd_table->write_fd);
+			// safe_close(read_fd);
+			// safe_close(write_fd);
 			return (false);
 		}
-		io_red_node = io_red_node->next;
+		io_red_list = io_red_list->next;
 	}
 	return (true);
 }

--- a/source/frontend/parser/cmd_table_symbol.c
+++ b/source/frontend/parser/cmd_table_symbol.c
@@ -51,7 +51,6 @@ bool	fill_redirect(t_list **token_list, t_cmd_table *cmd_table)
 
 	red_op = get_token_from_list(*token_list);
 	filename = get_token_from_list((*token_list)->next);
-	cmd_table->type = C_SIMPLE_CMD;
 	io_red = init_io_red();
 	if (!io_red)
 		return (false);
@@ -68,25 +67,23 @@ bool	handle_redirect(t_list **token_list, t_list_d **cmd_table_list)
 {
 	t_cmd_table	*cmd_table;
 	t_list_d	*cmd_table_node;
-	int			subshell_cnt;
 
 	cmd_table_node = ft_lstlast_d(*cmd_table_list);
-	subshell_cnt = 0;
-	while (cmd_table_node)
+	cmd_table = cmd_table_node->content;
+	if (cmd_table->type == C_NONE)
+		cmd_table->type = C_SIMPLE_CMD;
+	if (cmd_table->type == C_SIMPLE_CMD)
 	{
-		cmd_table = cmd_table_node->content;
-		if (cmd_table->type == C_SUBSHELL_END)
-			subshell_cnt++;
-		else if (cmd_table->type == C_SUBSHELL_START)
-			subshell_cnt--;
-		else if (cmd_table->type == C_SIMPLE_CMD || cmd_table->type == C_NONE)
-			if (!fill_redirect(token_list, cmd_table))
-				return (false);
-		if (subshell_cnt == 0)
-			break ;
-		cmd_table_node = cmd_table_node->prev;
+		if (!fill_redirect(token_list, cmd_table))
+			return (false);
 	}
-	(*token_list) = (*token_list)->next;
+	else
+	{
+		cmd_table = get_subshell_start(cmd_table_node);
+		if (!fill_redirect(token_list, cmd_table))
+			return (false);
+	}
+	*token_list = (*token_list)->next;
 	return (true);
 }
 

--- a/source/utils/cmd_table_status_utils.c
+++ b/source/utils/cmd_table_status_utils.c
@@ -30,6 +30,27 @@ t_cmd_table	*get_last_simple_cmd_table(t_list_d *cmd_table_list)
 	return (last_simple_cmd_table);
 }
 
+t_cmd_table	*get_subshell_start(t_list_d *cmd_table_node)
+{
+	t_cmd_table	*cmd_table;
+	int			subshell_cnt;
+
+	cmd_table = NULL;
+	subshell_cnt = 0;
+	while (cmd_table_node)
+	{
+		cmd_table = cmd_table_node->content;
+		if (cmd_table->type == C_SUBSHELL_END)
+			subshell_cnt++;
+		else if (cmd_table->type == C_SUBSHELL_START)
+			subshell_cnt--;
+		if (subshell_cnt <= 0)
+			break ;
+		cmd_table_node = cmd_table_node->prev;
+	}
+	return (cmd_table);
+}
+
 char	*get_cmd_name_from_list(t_list *simple_cmd_list)
 {
 	if (ft_lstsize_non_null(simple_cmd_list) == 0)


### PR DESCRIPTION
In the parser, instead of filling every simple cmd table  with a redirect from outside of a subshell, fill the subshell start cmd table.
In the executor, the redirection gets then inherited to all child processes of the subshell.

* Resolves #72 