### PR TITLE
[FIX] Expand target filename when handle io redirection

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -244,8 +244,8 @@ typedef enum e_is_open_pair_op
 typedef enum e_expander_op
 {
 	E_EXPAND		= 0b001,
-	E_RM_QUOTES		= 0b010,
-	E_HEREDOC		= 0b100
+	E_SPLIT_WORDS	= 0b010,
+	E_RM_QUOTES		= 0b100
 }	t_expander_op;
 
 typedef enum e_expander_task_type

--- a/include/defines.h
+++ b/include/defines.h
@@ -319,8 +319,7 @@ typedef struct s_pt_node
 typedef struct s_io_red
 {
 	int				type;
-	char			*in_file;
-	char			*out_file;
+	char			*filename;
 	char			*here_end;
 }	t_io_red;
 

--- a/include/defines.h
+++ b/include/defines.h
@@ -57,6 +57,7 @@
 # define EXIT_SUCCESS       0
 # define GENERAL_ERROR      1
 # define BAD_SUBSTITUTION   1
+# define AMBIGUOUS_REDIR    1
 # define MISUSE_BUILTIN     2
 # define SYNTAX_ERROR       2
 # define MALLOC_ERROR       2
@@ -148,6 +149,8 @@
 "%s: %s: command not found\n"
 # define ERROR_CANNOT_EXEC_FILE				\
 "%s: %s: cannot execute file: %s\n"
+# define ERROR_AMBIGUOUS_REDIRECT			\
+"%s: %s: ambiguous redirect\n"
 
 typedef enum e_heredoc_status
 {

--- a/include/executor.h
+++ b/include/executor.h
@@ -33,7 +33,7 @@ bool	restore_std_io(int saved_std_io[2]);
 bool	save_std_io(int saved_std_io[2]);
 bool	redirect_scmd_io(t_shell *shell, int *read_fd, int *write_fd);
 bool	redirect_subshell_io(t_shell *shell, t_cmd_table *cmd_table);
-bool	handle_io_redirect(
+int 	handle_io_redirect(
             t_shell *shell, int *read_fd, int *write_fd, t_list *io_red_list);
 
 /* Redirection - Pipe */

--- a/include/executor.h
+++ b/include/executor.h
@@ -32,8 +32,9 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node);
 bool	restore_std_io(int saved_std_io[2]);
 bool	save_std_io(int saved_std_io[2]);
 bool	redirect_scmd_io(t_shell *shell, int *read_fd, int *write_fd);
-bool	redirect_subshell_io(t_cmd_table *cmd_table);
-bool	handle_io_redirect(int *read_fd, int *write_fd, t_list *io_red_list);
+bool	redirect_subshell_io(t_shell *shell, t_cmd_table *cmd_table);
+bool	handle_io_redirect(
+            t_shell *shell, int *read_fd, int *write_fd, t_list *io_red_list);
 
 /* Redirection - Pipe */
 bool	need_pipe(t_list_d *cmd_table_node);

--- a/include/expander.h
+++ b/include/expander.h
@@ -23,7 +23,7 @@ int				ft_expander(char *str, t_list **lst, t_shell *shell,
 					t_expander_op op_mask);
 
 /* expander_task_list.c */
-bool			create_expander_task_list(t_list **task_list, char *new_str,
+bool			set_expander_task_list(t_list **task_list, char *new_str,
 					t_expander_op op_mask);
 bool			append_quote_task(t_list **task_list, char *new_str, size_t *i);
 bool			append_parameter_task(t_list **task_list, char *new_str,
@@ -44,10 +44,12 @@ void			skip_to_dollar_not_in_single_quotes(char *str, size_t *i);
 void			skip_to_expander_symbol(char *str, size_t *i);
 
 /* expansion_handler.c */
-bool			expand(char **new_str, t_list **lst, t_shell *shell,
+bool			handle_expansion(t_list **lst, char **new_str, t_shell *shell,
 					t_expander_op op_mask);
 bool			execute_expander_task_list(char **new_str, t_list *task_list,
 					t_shell *shell);
+bool			set_expanded_list(t_list **lst, char **new_str,
+					t_expander_op op_mask, t_list *task_list);
 
 /* null_expansion.c */
 bool			check_null_expansion(t_list **lst, t_list *task_list);

--- a/include/heredoc.h
+++ b/include/heredoc.h
@@ -7,11 +7,11 @@
 # include "signals.h"
 
 int		ft_heredoc(t_shell *shell);
+bool	is_here_end_quoted(char *here_end);
 bool	setup_tmp_hdfile(int cmdtable_id, t_io_red *io_red);
 int		expand_heredoc_content(t_shell *shell, char **content);
 bool	remove_here_end_quote(t_shell *shell,
 			t_io_red *io_red, bool *need_content_expansion);
-bool	write_content_to_file(char *content, char *filename);
 bool	append_line_to_list(t_list **line_list, char *line);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -126,7 +126,7 @@ bool		drop_num_stack(t_list **stack, int num, void (*del)(void *));
 t_list		*pop_num_stack(t_list **stack, int num);
 
 /* String utils */
-bool		replace_string_content(char **str, char *new_content);
+// bool		replace_string_content(char **str, char *new_content);
 bool		is_open_pair(unsigned char c, t_is_open_pair_op operation);
 bool		is_valid_varname(char *str);
 bool		is_valid_varname_char(char c);

--- a/include/utils.h
+++ b/include/utils.h
@@ -112,7 +112,7 @@ bool		is_subshell_symbol(int token_type);
 /* File utils */
 char		*generate_tmp_filename(int cmdtable_id, char *category);
 void		remove_file(char *filename);
-bool		append_line_to_file(char *line, char *filename);
+bool		write_content_to_file(char *content, char *filename);
 void		safe_close(int *fd);
 bool		is_dir(char *dir);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -85,7 +85,7 @@ bool		replace_env_value(
 /* Expansion utils */
 int			expand_list(t_shell *shell, t_list *list, t_list **expanded_list, \
 						t_expander_op op_mask);
-int			expand_array(t_shell *shell, char **array[], t_expander_op op_mask);
+int			expand_array(t_shell *shell, char **array[], t_expander_op op_mask);	// Not used
 
 /* Pipe utils */
 void		init_pipe(t_pipe *pipe);

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -72,11 +72,15 @@ void	safe_redirect_io_and_exec_builtin(t_shell *shell)
 void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 {
 	t_cmd_table	*cmd_table;
+	int			ret;
 
 	cmd_table = (*cmd_table_node)->content;
-	if (!handle_io_redirect(shell,
+	ret = handle_io_redirect(shell,
 			&shell->final_cmd_table->read_fd,
-			&shell->final_cmd_table->write_fd, cmd_table->io_red_list))
+			&shell->final_cmd_table->write_fd, cmd_table->io_red_list);
+	if (ret == MALLOC_ERROR)
+		raise_error_to_own_subprocess(shell, MALLOC_ERROR, "malloc failed");
+	if (ret == GENERAL_ERROR)
 	{
 		if (shell->subshell_level != 0)
 			ft_clean_and_exit_shell(shell, GENERAL_ERROR, NULL);

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -74,7 +74,8 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 	t_cmd_table	*cmd_table;
 
 	cmd_table = (*cmd_table_node)->content;
-	if (!handle_io_redirect(&shell->final_cmd_table->read_fd,
+	if (!handle_io_redirect(shell,
+			&shell->final_cmd_table->read_fd,
 			&shell->final_cmd_table->write_fd, cmd_table->io_red_list))
 	{
 		if (shell->subshell_level != 0)

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -12,7 +12,8 @@ void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 	t_final_cmd_table	*final_cmd_table;
 
 	final_cmd_table = shell->final_cmd_table;
-	if (!handle_io_redirect(&final_cmd_table->read_fd,
+	if (!handle_io_redirect(shell,
+			&final_cmd_table->read_fd,
 			&final_cmd_table->write_fd, cmd_table->io_red_list))
 		ft_clean_and_exit_shell(shell, GENERAL_ERROR, NULL);
 	if (!shell->final_cmd_table->simple_cmd[0])

--- a/source/backend/executor/handle_external.c
+++ b/source/backend/executor/handle_external.c
@@ -10,11 +10,15 @@ static void	handle_exec_error(t_shell *shell, char *exec_path);
 void	handle_external_cmd(t_shell *shell, t_cmd_table *cmd_table)
 {
 	t_final_cmd_table	*final_cmd_table;
+	int					ret;
 
 	final_cmd_table = shell->final_cmd_table;
-	if (!handle_io_redirect(shell,
+	ret = handle_io_redirect(shell,
 			&final_cmd_table->read_fd,
-			&final_cmd_table->write_fd, cmd_table->io_red_list))
+			&final_cmd_table->write_fd, cmd_table->io_red_list);
+	if (ret == MALLOC_ERROR)
+		raise_error_to_own_subprocess(shell, MALLOC_ERROR, "malloc failed");
+	if (ret == GENERAL_ERROR)
 		ft_clean_and_exit_shell(shell, GENERAL_ERROR, NULL);
 	if (!shell->final_cmd_table->simple_cmd[0])
 		ft_clean_and_exit_shell(shell, SUCCESS, NULL);

--- a/source/backend/executor/handle_subshell.c
+++ b/source/backend/executor/handle_subshell.c
@@ -18,6 +18,8 @@
 
 void	handle_subshell(t_shell *shell, t_list_d **cmd_table_node)
 {
+	int	ret;
+
 	shell->subshell_pid = fork();
 	if (shell->subshell_pid == -1)
 		raise_error_to_all_subprocess(
@@ -26,10 +28,12 @@ void	handle_subshell(t_shell *shell, t_list_d **cmd_table_node)
 	{
 		shell->subshell_level += 1;
 		handle_pipes_child(&shell->new_pipe, &shell->old_pipe);
-		if (!redirect_subshell_io(
-				shell, get_cmd_table_from_list(*cmd_table_node)))
-			ft_clean_and_exit_shell(
-				shell, CREATE_FD_ERROR, "subshell redirect failed");
+		ret = redirect_subshell_io(
+				shell, get_cmd_table_from_list(*cmd_table_node));
+		if (ret == MALLOC_ERROR)
+			raise_error_to_own_subprocess(shell, MALLOC_ERROR, "malloc failed");
+		if (ret == GENERAL_ERROR)
+			ft_clean_and_exit_shell(shell, GENERAL_ERROR, NULL);
 		*cmd_table_node = (*cmd_table_node)->next;
 		handle_process(shell, *cmd_table_node);
 	}

--- a/source/backend/executor/handle_subshell.c
+++ b/source/backend/executor/handle_subshell.c
@@ -26,7 +26,8 @@ void	handle_subshell(t_shell *shell, t_list_d **cmd_table_node)
 	{
 		shell->subshell_level += 1;
 		handle_pipes_child(&shell->new_pipe, &shell->old_pipe);
-		if (!redirect_subshell_io(get_cmd_table_from_list(*cmd_table_node)))
+		if (!redirect_subshell_io(
+				shell, get_cmd_table_from_list(*cmd_table_node)))
 			ft_clean_and_exit_shell(
 				shell, CREATE_FD_ERROR, "subshell redirect failed");
 		*cmd_table_node = (*cmd_table_node)->next;

--- a/source/backend/redirection/bind.c
+++ b/source/backend/redirection/bind.c
@@ -41,15 +41,14 @@ bool	redirect_subshell_io(t_shell *shell, t_cmd_table *cmd_table)
 {
 	int		read_fd;
 	int		write_fd;
-	bool	ret;
+	int		ret;
 
-	ret = true;
 	read_fd = -1;
 	write_fd = -1;
-	if (!handle_io_redirect(shell, &read_fd, &write_fd, cmd_table->io_red_list))
-		ret = false;
-	else if ((read_fd != -1 && dup2(read_fd, STDIN_FILENO) == -1) || \
-		(write_fd != -1 && dup2(write_fd, STDOUT_FILENO) == -1))
+	ret = handle_io_redirect(shell, &read_fd, &write_fd, cmd_table->io_red_list);
+	if (ret == SUCCESS && \
+		((read_fd != -1 && dup2(read_fd, STDIN_FILENO) == -1) || \
+		(write_fd != -1 && dup2(write_fd, STDOUT_FILENO) == -1)))
 	{
 		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
 		perror(NULL);

--- a/source/backend/redirection/bind.c
+++ b/source/backend/redirection/bind.c
@@ -37,7 +37,7 @@ bool	redirect_scmd_io(t_shell *shell, int *read_fd, int *write_fd)
 	return (ret);
 }
 
-bool	redirect_subshell_io(t_cmd_table *cmd_table)
+bool	redirect_subshell_io(t_shell *shell, t_cmd_table *cmd_table)
 {
 	int		read_fd;
 	int		write_fd;
@@ -46,7 +46,7 @@ bool	redirect_subshell_io(t_cmd_table *cmd_table)
 	ret = true;
 	read_fd = -1;
 	write_fd = -1;
-	if (!handle_io_redirect(&read_fd, &write_fd, cmd_table->io_red_list))
+	if (!handle_io_redirect(shell, &read_fd, &write_fd, cmd_table->io_red_list))
 		ret = false;
 	else if ((read_fd != -1 && dup2(read_fd, STDIN_FILENO) == -1) || \
 		(write_fd != -1 && dup2(write_fd, STDOUT_FILENO) == -1))

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -66,12 +66,12 @@ int	exec_heredoc(t_shell *shell,
 	ret = read_heredoc(shell, &line_list, io_red->here_end);
 	if (ret != SUCCESS)
 		return (ft_lstclear(&line_list, free),
-			remove_file(io_red->in_file), ret);
+			remove_file(io_red->filename), ret);
 	ret = handle_heredoc_content(
-			shell, io_red->in_file, &line_list, need_content_expansion);
+			shell, io_red->filename, &line_list, need_content_expansion);
 	ft_lstclear(&line_list, free);
 	if (ret != HEREDOC_SUCCESS)
-		return (remove_file(io_red->in_file), ret);
+		return (remove_file(io_red->filename), ret);
 	return (HEREDOC_SUCCESS);
 }
 

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -83,11 +83,12 @@ int	handle_heredoc(t_shell *shell, int cmdtable_id, t_list *io_red_list)
 
 	while (io_red_list && io_red_list->content)
 	{
-		need_content_expansion = true;
 		io_red = (t_io_red *)io_red_list->content;
 		if (io_red->type == T_HERE_DOC)
 		{
-			if (!remove_here_end_quote(shell, io_red, &need_content_expansion))
+			need_content_expansion = true;
+			if (is_here_end_quoted(io_red->here_end) && \
+				!remove_here_end_quote(shell, io_red, &need_content_expansion))
 				return (HEREDOC_ERROR);
 			shell->exit_code = SUCCESS;
 			ret = exec_heredoc(

--- a/source/backend/redirection/heredoc_utils.c
+++ b/source/backend/redirection/heredoc_utils.c
@@ -51,8 +51,7 @@ bool	remove_here_end_quote(
 	t_list	*expanded_list;
 
 	expanded_list = NULL;
-	if (is_here_end_quoted(io_red->here_end))
-		*need_content_expansion = false;
+	*need_content_expansion = false;
 	if (ft_expander(
 			io_red->here_end, &expanded_list, shell, E_RM_QUOTES) != SUCCESS)
 		return (ft_lstclear(&expanded_list, free), false);

--- a/source/backend/redirection/heredoc_utils.c
+++ b/source/backend/redirection/heredoc_utils.c
@@ -14,16 +14,16 @@ bool	setup_tmp_hdfile(int cmdtable_id, t_io_red *io_red)
 {
 	int	fd;
 
-	io_red->in_file = generate_tmp_filename(cmdtable_id, "hd");
-	if (!io_red->in_file)
+	io_red->filename = generate_tmp_filename(cmdtable_id, "hd");
+	if (!io_red->filename)
 		return (false);
-	fd = open(io_red->in_file,
+	fd = open(io_red->filename,
 			O_CREAT | O_RDWR | O_TRUNC,
 			(S_IRUSR + S_IWUSR) | S_IRGRP | S_IROTH);
 	if (fd < 0 || close(fd) == -1)
 	{
 		perror(PROGRAM_NAME);
-		return (ft_free_and_null((void **)&io_red->in_file), false);
+		return (ft_free_and_null((void **)&io_red->filename), false);
 	}
 	return (true);
 }

--- a/source/backend/redirection/heredoc_utils.c
+++ b/source/backend/redirection/heredoc_utils.c
@@ -34,7 +34,7 @@ int	expand_heredoc_content(t_shell *shell, char **content)
 	int		ret;
 
 	expanded_list = NULL;
-	ret = ft_expander(*content, &expanded_list, shell, E_HEREDOC);
+	ret = ft_expander(*content, &expanded_list, shell, E_EXPAND);
 	if (ret == MALLOC_ERROR)
 		return (ft_lstclear(&expanded_list, free), HEREDOC_ERROR);
 	if (ret == BAD_SUBSTITUTION)

--- a/source/backend/redirection/heredoc_utils.c
+++ b/source/backend/redirection/heredoc_utils.c
@@ -56,9 +56,10 @@ bool	remove_here_end_quote(
 	if (ft_expander(
 			io_red->here_end, &expanded_list, shell, E_RM_QUOTES) != SUCCESS)
 		return (ft_lstclear(&expanded_list, free), false);
-	if (!replace_string_content(&io_red->here_end, expanded_list->content))
-		return (ft_lstclear(&expanded_list, free), false);
-	return (ft_lstclear(&expanded_list, free), true);
+	free(io_red->here_end);
+	io_red->here_end = expanded_list->content;
+	ft_lstclear(&expanded_list, NULL);
+	return (true);
 }
 
 bool	append_line_to_list(t_list **line_list, char *line)

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -94,13 +94,11 @@ bool	handle_io_redirect(
 	while (io_red_list)
 	{
 		io_red = io_red_list->content;
-		if (io_red->type == T_HERE_DOC)
+		if (io_red->type != T_HERE_DOC)
 		{
-			io_red_list = io_red_list->next;
-			continue ;
+			if (expand_filename(shell, &io_red->filename) != SUCCESS)
+				return (false);
 		}
-		if (expand_filename(shell, &io_red->filename) != SUCCESS)
-			return (false);
 		if (!handle_redirect_by_type(read_fd, write_fd, io_red_list->content))
 			return (false);
 		io_red_list = io_red_list->next;

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -31,10 +31,8 @@ int	expand_filename(t_shell *shell, char **filename)
 		return (ft_lstclear(&expanded_list, free), AMBIGUOUS_REDIR);
 	}
 	free(*filename);
-	*filename = ft_strdup(expanded_list->content);
-	ft_lstclear(&expanded_list, free);
-	if (!*filename)
-		return (MALLOC_ERROR);
+	*filename = expanded_list->content;
+	ft_lstclear(&expanded_list, NULL);
 	return (SUCCESS);
 }
 

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -22,12 +22,9 @@ int	expand_filename(t_shell *shell, char **filename)
 	int			ret;
 
 	expanded_list = NULL;
-	ret = ft_expander(
-			*filename, &expanded_list, shell, E_EXPAND | E_RM_QUOTES);
-	if (ret == MALLOC_ERROR)
-		return (ft_lstclear(&expanded_list, free), MALLOC_ERROR);
-	if (ret == BAD_SUBSTITUTION)
-		return (ft_lstclear(&expanded_list, free), BAD_SUBSTITUTION);
+	ret = ft_expander(*filename, &expanded_list, shell, E_EXPAND | E_RM_QUOTES);
+	if (ret == MALLOC_ERROR || ret == BAD_SUBSTITUTION)
+		return (ft_lstclear(&expanded_list, free), ret);
 	if (ft_lstsize_non_null(expanded_list) != 1)
 	{
 		ft_dprintf(2, ERROR_AMBIGUOUS_REDIRECT, PROGRAM_NAME, *filename);

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -16,7 +16,6 @@
 #include "clean.h"
 #include "debug.h"
 
-
 int	expand_filename(t_shell *shell, char **filename)
 {
 	t_list		*expanded_list;
@@ -75,13 +74,13 @@ bool	handle_red_out(int *write_fd, char *filename, int o_flags)
 bool	handle_redirect_by_type(int *read_fd, int *write_fd, t_io_red *io_red)
 {
 	if (io_red->type == T_RED_IN || io_red->type == T_HERE_DOC)
-		return (handle_red_in(read_fd, io_red->in_file));
+		return (handle_red_in(read_fd, io_red->filename));
 	else if (io_red->type == T_RED_OUT)
 		return (handle_red_out(write_fd,
-				io_red->out_file, O_CREAT | O_RDWR | O_TRUNC));
+				io_red->filename, O_CREAT | O_RDWR | O_TRUNC));
 	else if (io_red->type == T_APPEND)
 		return (handle_red_out(write_fd,
-				io_red->out_file, O_CREAT | O_RDWR | O_APPEND));
+				io_red->filename, O_CREAT | O_RDWR | O_APPEND));
 	return (true);
 }
 
@@ -89,23 +88,18 @@ bool	handle_io_redirect(
 	t_shell *shell, int *read_fd, int *write_fd, t_list *io_red_list)
 {
 	t_io_red	*io_red;
-	char		**filename;
 
 	if (ft_lstsize_non_null(io_red_list) == 0)
 		return (true);
 	while (io_red_list)
 	{
 		io_red = io_red_list->content;
-		if (io_red->type == T_RED_IN)
-			filename = &io_red->in_file;
-		else if (io_red->type == T_RED_OUT || io_red->type == T_APPEND)
-			filename = &io_red->out_file;
-		else
+		if (io_red->type == T_HERE_DOC)
 		{
 			io_red_list = io_red_list->next;
 			continue ;
 		}
-		if (expand_filename(shell, filename) != SUCCESS)
+		if (expand_filename(shell, &io_red->filename) != SUCCESS)
 			return (false);
 		if (!handle_redirect_by_type(read_fd, write_fd, io_red_list->content))
 			return (false);

--- a/source/backend/redirection/io_redirect.c
+++ b/source/backend/redirection/io_redirect.c
@@ -79,24 +79,26 @@ bool	handle_redirect_by_type(int *read_fd, int *write_fd, t_io_red *io_red)
 	return (true);
 }
 
-bool	handle_io_redirect(
+int	handle_io_redirect(
 	t_shell *shell, int *read_fd, int *write_fd, t_list *io_red_list)
 {
 	t_io_red	*io_red;
+	int			ret;
 
 	if (ft_lstsize_non_null(io_red_list) == 0)
-		return (true);
+		return (SUCCESS);
 	while (io_red_list)
 	{
 		io_red = io_red_list->content;
 		if (io_red->type != T_HERE_DOC)
 		{
-			if (expand_filename(shell, &io_red->filename) != SUCCESS)
-				return (false);
+			ret = expand_filename(shell, &io_red->filename);
+			if (ret != SUCCESS)
+				return (ret);
 		}
 		if (!handle_redirect_by_type(read_fd, write_fd, io_red_list->content))
-			return (false);
+			return (GENERAL_ERROR);
 		io_red_list = io_red_list->next;
 	}
-	return (true);
+	return (SUCCESS);
 }

--- a/source/debug/print_cmd_table.c
+++ b/source/debug/print_cmd_table.c
@@ -25,8 +25,7 @@ void	print_io_red_list(t_list *io_red_list)
 	{
 		io_red = (t_io_red *)node->content;
 		printf("\ttype:    %d,\n", io_red->type);
-		printf("\tin_file: %s,\n", io_red->in_file);
-		printf("\tout_file: %s,\n", io_red->out_file);
+		printf("\tfilename: %s,\n", io_red->filename);
 		printf("\there_end: %s,\n", io_red->here_end);
 		printf("-----------------\n");
 		node = node->next;

--- a/source/debug/print_expanded_cmd_table.c
+++ b/source/debug/print_expanded_cmd_table.c
@@ -20,7 +20,8 @@ bool	expand_and_print(char *str, t_shell *shell)
 	int		ret;
 
 	expanded_list = NULL;
-	ret = ft_expander(str, &expanded_list, shell, E_EXPAND | E_RM_QUOTES);
+	ret = ft_expander(str, &expanded_list, shell,
+			E_EXPAND | E_SPLIT_WORDS | E_RM_QUOTES);
 	if (ret == MALLOC_ERROR)
 		return (printf("malloc failed in expander"), false);
 	if (ret == BAD_SUBSTITUTION)

--- a/source/debug/print_expanded_cmd_table.c
+++ b/source/debug/print_expanded_cmd_table.c
@@ -84,11 +84,8 @@ bool	print_expanded_io_red_list(t_cmd_table *cmd_table, t_shell *shell)
 	{
 		io_red = (t_io_red *)node->content;
 		printf("\ttype:     %d", io_red->type);
-		printf("\n\tin_file:  ");
-		if (!expand_and_print(io_red->in_file, shell))
-			return (false);
-		printf("\n\tout_file: ");
-		if (!expand_and_print(io_red->out_file, shell))
+		printf("\n\filename:  ");
+		if (!expand_and_print(io_red->filename, shell))
 			return (false);
 		printf("\n\there_end: ");
 		if (!expand_and_print(io_red->here_end, shell))

--- a/source/frontend/expander/bad_substitution.c
+++ b/source/frontend/expander/bad_substitution.c
@@ -53,12 +53,12 @@ bool	is_bad_substitution(char *str, t_expander_op op_mask)
 {
 	size_t	i;
 
-	if (!(op_mask & (E_EXPAND | E_HEREDOC)))
+	if (!(op_mask & E_EXPAND))
 		return (false);
 	i = 0;
 	while (str[i])
 	{
-		if (!(op_mask & E_HEREDOC))
+		if (op_mask & E_RM_QUOTES)
 			skip_to_dollar_not_in_single_quotes(str, &i);
 		if (!str[i])
 			break ;

--- a/source/frontend/expander/expander.c
+++ b/source/frontend/expander/expander.c
@@ -26,7 +26,7 @@ int	ft_expander(char *str, t_list **lst, t_shell *shell, t_expander_op op_mask)
 		return (MALLOC_ERROR);
 	if (is_bad_substitution(new_str, op_mask))
 		return (free(new_str), BAD_SUBSTITUTION);
-	if (!expand(&new_str, lst, shell, op_mask))
+	if (!handle_expansion(lst, &new_str, shell, op_mask))
 		return (free(new_str), MALLOC_ERROR);
 	return (SUCCESS);
 }

--- a/source/frontend/expander/expander_task_list.c
+++ b/source/frontend/expander/expander_task_list.c
@@ -1,7 +1,7 @@
 #include "expander.h"
 #include "utils.h"
 
-bool	create_expander_task_list(t_list **task_list, char *new_str,
+bool	set_expander_task_list(t_list **task_list, char *new_str,
 			t_expander_op op_mask)
 {
 	size_t	i;
@@ -13,7 +13,7 @@ bool	create_expander_task_list(t_list **task_list, char *new_str,
 	{
 		if (ft_strchr(QUOTES, new_str[i]) && op_mask & E_RM_QUOTES)
 			ret = append_quote_task(task_list, new_str, &i);
-		else if (new_str[i] == '$' && op_mask & (E_EXPAND | E_HEREDOC))
+		else if (new_str[i] == '$' && op_mask & E_EXPAND)
 			ret = append_parameter_task(task_list, new_str, &i, op_mask);
 		else
 			i++;
@@ -51,7 +51,7 @@ bool	append_parameter_task(t_list **task_list, char *new_str, size_t *i,
 	offset = get_offset(&new_str[*i]);
 	if (is_valid_varname_start(new_str[*i + offset]))
 	{
-		if (!is_open_pair('"', OP_GET) && !(op_mask & E_HEREDOC))
+		if (!is_open_pair('"', OP_GET) && op_mask & E_SPLIT_WORDS)
 			type = ET_VAR;
 		else
 			type = ET_VAR_NO_SPLIT;

--- a/source/frontend/expander/expansion_handler.c
+++ b/source/frontend/expander/expansion_handler.c
@@ -1,15 +1,14 @@
 #include "expander.h"
 
-bool	expand(char **new_str, t_list **lst, t_shell *shell,
+bool	handle_expansion(t_list **lst, char **new_str, t_shell *shell,
 			t_expander_op op_mask)
 {
 	t_list	*task_list;
 
 	task_list = NULL;
-	if (!create_expander_task_list(&task_list, *new_str, op_mask) || \
+	if (!set_expander_task_list(&task_list, *new_str, op_mask) || \
 		!execute_expander_task_list(new_str, task_list, shell) || \
-		!split_words(lst, new_str, task_list) || \
-		!check_null_expansion(lst, task_list))
+		!set_expanded_list(lst, new_str, op_mask, task_list))
 		return (ft_lstclear(&task_list, (void *)free_expander_task), false);
 	ft_lstclear(&task_list, (void *)free_expander_task);
 	return (true);
@@ -36,4 +35,19 @@ bool	execute_expander_task_list(
 		task_list = task_list->next;
 	}
 	return (ret);
+}
+
+bool	set_expanded_list(
+	t_list **lst, char **new_str, t_expander_op op_mask, t_list *task_list)
+{
+	if (op_mask & E_SPLIT_WORDS)
+	{
+		if (!split_words(lst, new_str, task_list))
+			return (false);
+	}
+	else if (!ft_lstnew_back(lst, *new_str))
+		return (false);
+	if (!check_null_expansion(lst, task_list))
+		return (false);
+	return (true);
 }

--- a/source/frontend/parser/cmd_table_symbol.c
+++ b/source/frontend/parser/cmd_table_symbol.c
@@ -33,12 +33,10 @@ bool	fill_red_node(t_io_red *io_red, int type, char *data)
 	if (!dup_data)
 		return (false);
 	io_red->type = type;
-	if (type == T_RED_IN)
-		io_red->in_file = dup_data;
-	else if (type == T_HERE_DOC)
+	if (type == T_HERE_DOC)
 		io_red->here_end = dup_data;
-	else if (type == T_RED_OUT || type == T_APPEND)
-		io_red->out_file = dup_data;
+	else
+		io_red->filename = dup_data;
 	return (true);
 }
 

--- a/source/utils/expansion_utils.c
+++ b/source/utils/expansion_utils.c
@@ -36,7 +36,7 @@ int	expand_list(t_shell *shell, t_list *list, t_list **expanded_list, \
 	return (ret);
 }
 
-int	expand_array(t_shell *shell, char **array[], t_expander_op op_mask)
+int	expand_array(t_shell *shell, char **array[], t_expander_op op_mask)	// Not used
 {
 	t_list	*expanded_list;
 	int		i;

--- a/source/utils/final_cmd_table_setup_utils.c
+++ b/source/utils/final_cmd_table_setup_utils.c
@@ -20,8 +20,8 @@ bool	expand_simple_cmd(t_shell *shell, t_list *simple_cmd_list)
 	int			ret;
 
 	expanded_list = NULL;
-	ret = expand_list(
-			shell, simple_cmd_list, &expanded_list, E_EXPAND | E_RM_QUOTES);
+	ret = expand_list(shell, simple_cmd_list, &expanded_list,
+			E_EXPAND | E_SPLIT_WORDS | E_RM_QUOTES);
 	if (ret == MALLOC_ERROR)
 		return (ft_lstclear(&expanded_list, free), false);
 	else if (ret == BAD_SUBSTITUTION)

--- a/source/utils/io_redirect_utils.c
+++ b/source/utils/io_redirect_utils.c
@@ -21,16 +21,14 @@ t_io_red	*init_io_red(void)
 	if (!io_red)
 		return (NULL);
 	io_red->type = T_NONE;
-	io_red->in_file = NULL;
-	io_red->out_file = NULL;
+	io_red->filename = NULL;
 	io_red->here_end = NULL;
 	return (io_red);
 }
 
 void	free_io_red(t_io_red *io_red)
 {
-	ft_free_and_null((void *)&io_red->in_file);
-	ft_free_and_null((void *)&io_red->out_file);
+	ft_free_and_null((void *)&io_red->filename);
 	ft_free_and_null((void *)&io_red->here_end);
 	ft_free_and_null((void *)&io_red);
 }

--- a/source/utils/string_utils.c
+++ b/source/utils/string_utils.c
@@ -12,17 +12,17 @@
 
 #include "utils.h"
 
-bool	replace_string_content(char **str, char *new_content)
-{
-	char	*tmp;
+// bool	replace_string_content(char **str, char *new_content)
+// {
+// 	char	*tmp;
 
-	tmp = ft_strdup(new_content);
-	if (!tmp)
-		return (false);
-	free(*str);
-	*str = tmp;
-	return (true);
-}
+// 	tmp = ft_strdup(new_content);
+// 	if (!tmp)
+// 		return (false);
+// 	free(*str);
+// 	*str = tmp;
+// 	return (true);
+// }
 
 int	get_list_strlen(t_list *list, char *delim)
 {


### PR DESCRIPTION
not working...

```sh
bash-5.1$ export A="     "
bash-5.1$ echo 1 > abc > $A > def
```