### PR TITLE
[FIX] Fix Ctrl+D in heredoc printing one too much line

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -125,7 +125,7 @@
 # define ERROR_PARSER_SYNTAX				\
 "%s: syntax error near unexpected token `%s'\n"
 # define ERROR_HEREDOC_UNEXPECTED_EOF		\
-"\n%s: warning: here-document delimited by end-of-file (wanted `%s')\n"
+"%s: warning: here-document delimited by end-of-file (wanted `%s')\n"
 # define ERROR_EXPANDER_BAD_SUBSTITUTION	\
 "%s: %s: bad substitution\n"
 # define ERROR_EXIT_TOO_MANY_ARGS			\


### PR DESCRIPTION
In commit ca5310f it was necessary to put a `\n` at the beginning of the `ERROR_HEREDOC_UNEXPECTED_EOF` message. This was bc the error message appeared in the same line as the heredoc prompt.
This is not the case any more.
- [x] Do you know why it was needed back then, but not anymore?

---
* Resolves [BUG] Ctrl+D in heredoc prints one too much line #215