### PR TITLE
[FIX] Fix unresponsiveness after terminal window resizing

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -64,13 +64,17 @@ bool	ft_read_input(t_shell *shell)
 	{
 		errno = SUCCESS;
 		line = get_next_line(fileno(stdin));
+		if (errno != SUCCESS)
+			return (false);
 		if (line)
 		{
 			shell->input_line = ft_strtrim(line, "\n");
 			free(line);
 		}
 	}
-	if (errno != SUCCESS)
+	if (errno == EINTR)
+		errno = SUCCESS;
+	else if (errno != SUCCESS)
 		return (false);
 	if (shell->input_line && *shell->input_line)
 		add_history(shell->input_line);


### PR DESCRIPTION
* I made a new branch and PR bc the branch from #209 has a typo.

---

When the terminal window gets resized, `SIGWINCH` gets sent to the `readline()` function which then sets `errno` to `EINTR`. However, `readline()` still returns the string it read as usual.

All other `errno` checks are necessary to protect against `malloc()` and `read()` failures. 
I tested and can confirm that `read()` does not listen to `SIGWINCH` and therefore also doesn't set `errno` to `EINTR` in such a case.

* Resolves #200