### PR TITLE
[STYLE] Change default cmd_table type and remove dead return statements

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc, clang, clang-12]
     steps:
       - name: Checkout source branch of pull request
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,13 +9,17 @@ jobs:
     name: Compilation Test
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
     steps:
       - name: Checkout source branch of pull request
         uses: actions/checkout@v4
       - name: Set up test environment
         uses: ./.github/actions/setup
       - name: 🔨 Compile with Makefile
-        run: make
+        run: make CC="${{ matrix.compiler }}"
 
   prepare_test_matrix:
     name: Prepare Test Matrix
@@ -36,12 +40,12 @@ jobs:
   memory_leak_test:
     name: Memory Leak Test
     needs: prepare_test_matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         test_script: ${{ fromJson(needs.prepare_test_matrix.outputs.test_matrix) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - name: Checkout source branch of pull request
         uses: actions/checkout@v4

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -92,8 +92,8 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 	{
 		if (!redirect_scmd_io(shell, &shell->final_cmd_table->read_fd,
 				&shell->final_cmd_table->write_fd))
-			return (raise_error_to_own_subprocess(
-					shell, CREATE_FD_ERROR, "fd bind failed"));
+			raise_error_to_own_subprocess(
+				shell, CREATE_FD_ERROR, "fd bind failed");
 		exec_builtin_cmd(shell);
 	}
 	*cmd_table_node = (*cmd_table_node)->next;

--- a/source/backend/executor/handle_simple_cmd.c
+++ b/source/backend/executor/handle_simple_cmd.c
@@ -37,8 +37,7 @@ void	exec_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 	t_cmd_table	*cmd_table;
 
 	if (!set_final_cmd_table(shell, (*cmd_table_node)->content))
-		return (raise_error_to_own_subprocess(
-				shell, MALLOC_ERROR, "malloc failed"));
+		raise_error_to_own_subprocess(shell, MALLOC_ERROR, "malloc failed");
 	cmd_table = get_cmd_table_from_list(*cmd_table_node);
 	if (is_builtin(shell->final_cmd_table->simple_cmd[0]))
 	{

--- a/source/frontend/parser/cmd_table_symbol.c
+++ b/source/frontend/parser/cmd_table_symbol.c
@@ -70,8 +70,6 @@ bool	handle_redirect(t_list **token_list, t_list_d **cmd_table_list)
 
 	cmd_table_node = ft_lstlast_d(*cmd_table_list);
 	cmd_table = cmd_table_node->content;
-	if (cmd_table->type == C_NONE)
-		cmd_table->type = C_SIMPLE_CMD;
 	if (cmd_table->type == C_SIMPLE_CMD)
 	{
 		if (!fill_redirect(token_list, cmd_table))

--- a/source/utils/cmd_table_operation_utils.c
+++ b/source/utils/cmd_table_operation_utils.c
@@ -48,11 +48,8 @@ t_cmd_table	*get_cmd_table_from_list(t_list_d *cmd_table_node)
 
 bool	append_cmd_table_by_scenario(int token_type, t_list_d **cmd_table_list)
 {
-	t_cmd_table	*cmd_table;
-
 	if (*cmd_table_list)
 	{
-		cmd_table = ft_lstlast_d(*cmd_table_list)->content;
 		if (token_type == T_END)
 			return (true);
 		if (get_last_simple_cmd_table(*cmd_table_list) && \

--- a/source/utils/cmd_table_operation_utils.c
+++ b/source/utils/cmd_table_operation_utils.c
@@ -32,7 +32,7 @@ t_cmd_table	*init_cmd_table(void)
 	cmd_table->subshell_level = 0;
 	cmd_table->read_fd = -1;
 	cmd_table->write_fd = -1;
-	cmd_table->type = C_NONE;
+	cmd_table->type = C_SIMPLE_CMD;
 	cmd_table->assignment_list = NULL;
 	cmd_table->simple_cmd_list = NULL;
 	cmd_table->io_red_list = NULL;
@@ -53,7 +53,7 @@ bool	append_cmd_table_by_scenario(int token_type, t_list_d **cmd_table_list)
 	if (*cmd_table_list)
 	{
 		cmd_table = ft_lstlast_d(*cmd_table_list)->content;
-		if (token_type == T_END || cmd_table->type == C_NONE)
+		if (token_type == T_END)
 			return (true);
 		if (get_last_simple_cmd_table(*cmd_table_list) && \
 			(is_io_red_op(token_type) || is_word(token_type)))

--- a/source/utils/cmd_table_status_utils.c
+++ b/source/utils/cmd_table_status_utils.c
@@ -23,7 +23,7 @@ t_cmd_table	*get_last_simple_cmd_table(t_list_d *cmd_table_list)
 		cur_type = ((t_cmd_table *)cmd_table_list->content)->type;
 		if (cur_type == C_PIPE || cur_type == C_AND || cur_type == C_OR)
 			last_simple_cmd_table = NULL;
-		else if (cur_type == C_SIMPLE_CMD || cur_type == C_NONE)
+		else if (cur_type == C_SIMPLE_CMD)
 			last_simple_cmd_table = cmd_table_list->content;
 		cmd_table_list = cmd_table_list->next;
 	}


### PR DESCRIPTION
- **Set C_SIMPLE_CMD as the default cmd_table type.**
  This make more sense bc f.e. `> outfile` should still get a command table and get to the executor.
  And in the executor, we expect at least a C_SIMPLE_CMD in order to do anything with it.

- **The return statements are a bit misleading.**
  They are an artifact from before the error handling functions via signals were changed.
  `SIGTERM` only doesn't exit in subshell level 0.
  Therefore, in any functions that are accessable from the main process, a continuation after raise_error has to be considered.
  `exec_simple_cmd()` is not accessable from the main process.
  And in `handle_builtin()`, there is an explicit check that this is not in subshell level 0.

- **Improve compilation tests in GH Actions.**
  When just running cc, the default is gcc.
  When just running clang, the default is clang-14.
  I added a matrix to test the compilation with gcc, clang-14 and clang-12 (clang-12 is the default on computers on campus).
  - [ ] @LeaYeh You will have to update the ruleset of for compilation tests on GitHub.