### PR TITLE
[FIX] Fix IO files being created in child process when no scmd

### DIFF
--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -27,7 +27,7 @@ void	handle_simple_cmd(t_shell *shell, t_list_d **cmd_table_node)
 	if (ret != SUCCESS)
 		return (free(cmd_name),
 			handle_expansion_error(shell, cmd_table_node, ret));
-	if (is_builtin(cmd_name))
+	if (!cmd_name || is_builtin(cmd_name))
 	{
 		free(cmd_name);
 		if (set_final_cmd_table(shell, cmd_table) != SUCCESS)

--- a/source/backend/executor/handle_builtin.c
+++ b/source/backend/executor/handle_builtin.c
@@ -93,9 +93,10 @@ void	handle_builtin(t_shell *shell, t_list_d **cmd_table_node)
 		if (shell->subshell_level != 0)
 			clean_and_exit_shell(shell, shell->exit_code, NULL);
 	}
-	else if (shell->subshell_level == 0)
+	else if (shell->final_cmd_table->simple_cmd[0] && \
+				shell->subshell_level == 0)
 		safe_redirect_io_and_exec_builtin(shell);
-	else
+	else if (shell->final_cmd_table->simple_cmd[0])
 		redirect_io_and_exec_builtin(shell);
 	if (shell->exit_code == BUILTIN_ERROR)
 		raise_error_to_own_subprocess(shell, MALLOC_ERROR, NULL);


### PR DESCRIPTION
I tested bash with `ulimit -u`.
External commands failed to fork, but an input like `> outfile` still created the outfile. This means, with no simple command, bash creates the files in its own process. For a commands like `ls > outfile2`, the file was not created with ulimit -u active.