### PR TITLE
[FIX] Fix exit builtin with whitespace in arguments

### DIFF
--- a/source/builtins/exit_utils.c
+++ b/source/builtins/exit_utils.c
@@ -31,7 +31,7 @@ bool	valid_number(char *str)
 		i++;
 	if (is_sign(str[i]))
 		i++;
-	if (!str[i])
+	if (!ft_isdigit(str[i]))
 		return (false);
 	while (str[i])
 	{

--- a/source/builtins/exit_utils.c
+++ b/source/builtins/exit_utils.c
@@ -24,10 +24,10 @@ bool	valid_number(char *str)
 {
 	int	i;
 
-	if (!str || !*str)
+	if (!*str)
 		return (false);
 	i = 0;
-	if (ft_strlen(str) > 1 && is_sign(str[i]))
+	if (is_sign(str[i]))
 		i++;
 	while (str[i])
 	{
@@ -68,7 +68,7 @@ int	get_args_error(char *args[])
 	type = EX_NORM_ARGS;
 	if (!valid_number(args[1]) || is_atol_overflow(args[1]))
 		type = EX_NOT_NUMERIC;
-	else if (get_array_len(args) > 2)
+	else if (args[2])
 		type = EX_TOO_MANY_ARGS;
 	return (type);
 }

--- a/source/builtins/exit_utils.c
+++ b/source/builtins/exit_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exit_utils.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 17:40:30 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/18 17:40:31 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/03/20 00:36:35 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,8 +38,12 @@ bool	valid_number(char *str)
 		if (ft_isdigit(str[i]))
 			i++;
 		else
-			return (false);
+			break ;
 	}
+	while (str[i] && ft_strchr(WHITESPACE, str[i]))
+		i++;
+	if (str[i])
+		return (false);
 	return (true);
 }
 
@@ -47,6 +51,7 @@ bool	is_atol_overflow(char *str)
 {
 	int		i;
 	char	*long_max;
+	int		num_len;
 
 	i = 0;
 	while (str[i] && ft_strchr(WHITESPACE, str[i]))
@@ -59,8 +64,11 @@ bool	is_atol_overflow(char *str)
 		i++;
 	while (str[i] == '0')
 		i++;
-	if (ft_strlen(&str[i]) < ft_strlen(long_max) || \
-		ft_strcmp(&str[i], long_max) <= 0)
+	num_len = 0;
+	while (ft_isdigit(str[i + num_len]))
+		num_len++;
+	if (num_len < (int)ft_strlen(long_max) || \
+		ft_strncmp(&str[i], long_max, num_len) <= 0)
 		return (false);
 	return (true);
 }

--- a/source/builtins/exit_utils.c
+++ b/source/builtins/exit_utils.c
@@ -27,6 +27,8 @@ bool	valid_number(char *str)
 	if (!*str)
 		return (false);
 	i = 0;
+	while (ft_strchr(WHITESPACE, str[i]))
+		i++;
 	if (is_sign(str[i]))
 		i++;
 	while (str[i])
@@ -45,6 +47,8 @@ bool	is_atol_overflow(char *str)
 	char	*long_max;
 
 	i = 0;
+	while (ft_strchr(WHITESPACE, str[i]))
+		i++;
 	if (str[i] == '-')
 		long_max = "9223372036854775808";
 	else

--- a/source/builtins/exit_utils.c
+++ b/source/builtins/exit_utils.c
@@ -31,6 +31,8 @@ bool	valid_number(char *str)
 		i++;
 	if (is_sign(str[i]))
 		i++;
+	if (!str[i])
+		return (false);
 	while (str[i])
 	{
 		if (ft_isdigit(str[i]))

--- a/source/builtins/exit_utils.c
+++ b/source/builtins/exit_utils.c
@@ -27,7 +27,7 @@ bool	valid_number(char *str)
 	if (!*str)
 		return (false);
 	i = 0;
-	while (ft_strchr(WHITESPACE, str[i]))
+	while (str[i] && ft_strchr(WHITESPACE, str[i]))
 		i++;
 	if (is_sign(str[i]))
 		i++;
@@ -49,7 +49,7 @@ bool	is_atol_overflow(char *str)
 	char	*long_max;
 
 	i = 0;
-	while (ft_strchr(WHITESPACE, str[i]))
+	while (str[i] && ft_strchr(WHITESPACE, str[i]))
 		i++;
 	if (str[i] == '-')
 		long_max = "9223372036854775808";


### PR DESCRIPTION
The following cases should all be considered as valid arguments for exit:
```
exit "         5"
```
```
exit "         5                                                                      "
```

The following should **not** be considered a valid arguments for exit:
```
exit +
```
```
exit -
```

Christian was so kind to let us know of this issue. He noticed it when looking through our code on his own, and he didn't even need to test it to see the issue.