### PR TITLE
[FIX] Fix exit codes from exit builtin

### DIFF
--- a/source/builtins/exit.c
+++ b/source/builtins/exit.c
@@ -35,11 +35,9 @@ void	exec_exit(t_shell *shell, char *args[])
 	int	args_error;
 
 	args_error = get_args_error(args);
-	if (args_error == EX_NO_ARGS)
-		shell->exit_code = SUCCESS;
-	else if (args_error == EX_NORM_ARGS)
+	if (args_error == EX_NORM_ARGS)
 		shell->exit_code = (ft_atol(args[1])) % 256;
-	else
+	else if (args_error != EX_NO_ARGS)
 		shell->exit_code = args_error;
 	handle_exit(shell, args_error);
 }

--- a/source/builtins/exit_utils.c
+++ b/source/builtins/exit_utils.c
@@ -67,10 +67,10 @@ bool	is_atol_overflow(char *str)
 	num_len = 0;
 	while (ft_isdigit(str[i + num_len]))
 		num_len++;
-	if (num_len < (int)ft_strlen(long_max) || \
-		ft_strncmp(&str[i], long_max, num_len) <= 0)
-		return (false);
-	return (true);
+	if (num_len > (int)ft_strlen(long_max) || \
+		ft_strncmp(&str[i], long_max, num_len) > 0)
+		return (true);
+	return (false);
 }
 
 int	get_args_error(char *args[])


### PR DESCRIPTION
Test cases:
```sh
exit 1111111111111111111111111111111111
```
```sh
exit 9999999999999999999999999999999999
```
```sh
exit "     9223372036854775807                                      "
```