### PR TITLE
[FIX] Print exit msg to stderr

### DIFF
--- a/source/backend/builtins/exit/exit.c
+++ b/source/backend/builtins/exit/exit.c
@@ -17,7 +17,7 @@
 void	handle_exit(t_shell *shell, int args_error)
 {
 	if (shell->subshell_level == 0 && !TEST_MODE)
-		printf(EXIT_MSG);
+		ft_dprintf(STDERR_FILENO, EXIT_MSG);
 	if (args_error == EX_TOO_MANY_ARGS)
 	{
 		ft_dprintf(2, ERROR_EXIT_TOO_MANY_ARGS, PROGRAM_NAME, "exit");

--- a/source/backend/builtins/exit/exit_utils.c
+++ b/source/backend/builtins/exit/exit_utils.c
@@ -77,7 +77,7 @@ int	get_args_error(char *args[])
 {
 	int	type;
 
-	if (!args[1])
+	if (!args || !args[1])
 		return (EX_NO_ARGS);
 	type = EX_NORM_ARGS;
 	if (!valid_number(args[1]) || is_atol_overflow(args[1]))

--- a/source/main.c
+++ b/source/main.c
@@ -33,7 +33,7 @@ int	main(void)
 		if (!shell.input_line)
 		{
 			if (!TEST_MODE)
-				printf(EXIT_MSG);
+				ft_dprintf(STDERR_FILENO, EXIT_MSG);
 			clean_and_exit_shell(&shell, shell.exit_code, NULL);
 		}
 		if (!lexer(&shell) || !parser(&shell))

--- a/source/main.c
+++ b/source/main.c
@@ -12,6 +12,7 @@
 
 #include "clean.h"
 #include "init.h"
+#include "builtins.h"
 #include "lexer.h"
 #include "parser.h"
 #include "executor.h"
@@ -31,11 +32,7 @@ int	main(void)
 		if (!read_input(&shell))
 			continue ;
 		if (!shell.input_line)
-		{
-			if (!TEST_MODE)
-				ft_dprintf(STDERR_FILENO, EXIT_MSG);
-			clean_and_exit_shell(&shell, shell.exit_code, NULL);
-		}
+			exec_exit(&shell, NULL);
 		if (!lexer(&shell) || !parser(&shell))
 		{
 			reset_submodule_variable(&shell);


### PR DESCRIPTION
- Also call the exit builtin when receiving EOF - bash does it the same way.

I tested it in bash like this and the `exit` message gets output to the file:
```sh
bash-5.1$ exit 2>/file
```

I also looked at the source code of bash and found the following lines that confirm that the exit builtin prints to stderr:
```c
int
exit_builtin (list)
     WORD_LIST *list;
{
  CHECK_HELPOPT (list);

  if (interactive)
    {
      fprintf (stderr, login_shell ? _("logout\n") : "exit\n");
      fflush (stderr);
    }

  return (exit_or_logout (list));
}
```
https://github.com/bminor/bash/blob/f3b6bd19457e260b65d11f2712ec3da56cef463f/builtins/exit.def#L64

And when receiving EOF via Ctrl+D bash just calls the exit builtin:
```c
/* If we have EOF as the only input unit, this user wants to leave
   the shell.  If the shell is not interactive, then just leave.
   Otherwise, if ignoreeof is set, and we haven't done this the
   required number of times in a row, print a message. */
static void
handle_eof_input_unit ()
{
  if (interactive)
    {
      /* shell.c may use this to decide whether or not to write out the
	 history, among other things.  We use it only for error reporting
	 in this file. */
      if (EOF_Reached)
	EOF_Reached = 0;

      /* If the user wants to "ignore" eof, then let her do so, kind of. */
      if (ignoreeof)
	{
	  if (eof_encountered < eof_encountered_limit)
	    {
	      fprintf (stderr, _("Use \"%s\" to leave the shell.\n"),
		       login_shell ? "logout" : "exit");
	      eof_encountered++;
	      /* Reset the parsing state. */
	      last_read_token = current_token = '\n';
	      /* Reset the prompt string to be $PS1. */
	      prompt_string_pointer = (char **)NULL;
	      prompt_again (0);
	      return;
	    }
	}

      /* In this case EOF should exit the shell.  Do it now. */
      reset_parser ();

      last_shell_builtin = this_shell_builtin;
      this_shell_builtin = exit_builtin;
      exit_builtin ((WORD_LIST *)NULL);
    }
  else
    {
      /* We don't write history files, etc., for non-interactive shells. */
      EOF_Reached = 1;
    }
}
```
https://github.com/bminor/bash/blob/f3b6bd19457e260b65d11f2712ec3da56cef463f/y.tab.c#L8689