### PR TITLE
[REFACTOR] Merge `SIGINT` handling of heredoc with standard

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -153,8 +153,7 @@ typedef enum e_state
 	SIG_DEFAULT		= 0,
 	SIG_IGNORE,
 	SIG_STANDARD,
-	SIG_RECORD,
-	SIG_HEREDOC
+	SIG_RECORD
 }	t_state;
 
 typedef enum e_pt_col

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/26 15:04:52 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/19 15:15:50 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/03/21 22:45:04 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,9 +75,7 @@ void	executor(t_shell *shell)
 {
 	int	heredoc_status;
 
-	setup_signal(shell, SIGINT, SIG_HEREDOC);
 	heredoc_status = heredoc(shell);
-	setup_signal(shell, SIGINT, SIG_STANDARD);
 	if (heredoc_status == HEREDOC_ERROR)
 		clean_and_exit_shell(shell, MALLOC_ERROR, "heredoc malloc/fd error");
 	else if (heredoc_status == HEREDOC_ABORT)

--- a/source/shell_struct/init.c
+++ b/source/shell_struct/init.c
@@ -33,7 +33,6 @@ bool	init_shell(t_shell *shell)
 		return (false);
 	handle_signal_std(0, NULL, shell);
 	handle_signal_record(0, NULL, shell);
-	handle_signal_heredoc(0, NULL, shell);
 	setup_signal(shell, SIGINT, SIG_STANDARD);
 	setup_signal(shell, SIGABRT, SIG_STANDARD);
 	setup_signal(shell, SIGTERM, SIG_STANDARD);

--- a/source/signal/signal_handler.c
+++ b/source/signal/signal_handler.c
@@ -23,10 +23,9 @@ void	handle_signal_std(int signo, siginfo_t *info, void *context)
 	shell->exit_code = TERM_BY_SIGNAL + signo;
 	if (signo == SIGINT)
 	{
-		printf("\n");
+		ioctl(STDIN_FILENO, TIOCSTI, "\n");
 		rl_on_new_line();
 		rl_replace_line("", 0);
-		rl_redisplay();
 	}
 	else if (signo == SIGABRT)
 	{
@@ -53,25 +52,6 @@ void	handle_signal_record(int signo, siginfo_t *info, void *context)
 	shell->signal_record = signo;
 }
 
-void	handle_signal_heredoc(int signo, siginfo_t *info, void *context)
-{
-	static t_shell	*shell;
-
-	(void)info;
-	if (!shell)
-	{
-		shell = context;
-		return ;
-	}
-	shell->exit_code = TERM_BY_SIGNAL + signo;
-	if (signo == SIGINT)
-	{
-		ioctl(STDIN_FILENO, TIOCSTI, "\n");
-		rl_on_new_line();
-		rl_replace_line("", 0);
-	}
-}
-
 void	setup_signal(t_shell *shell, int signo, t_state state)
 {
 	struct sigaction	sa;
@@ -87,8 +67,6 @@ void	setup_signal(t_shell *shell, int signo, t_state state)
 		sa.sa_sigaction = handle_signal_std;
 	else if (state == SIG_RECORD)
 		sa.sa_sigaction = handle_signal_record;
-	else if (state == SIG_HEREDOC)
-		sa.sa_sigaction = handle_signal_heredoc;
 	if (sigaction(signo, &sa, NULL) != 0)
 		perror("The signal is not supported:");
 }


### PR DESCRIPTION
The heredoc signal handler does exactly the same thing as the standard signal handler for `SIGINT`.
And it makes sense that the behavior of `SIGINT` should be the same.