### PR TITLE
[BUILD] Add `ffclean` goal to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/12/23 03:22:46 by ldulling          #+#    #+#              #
-#    Updated: 2024/03/19 17:34:16 by ldulling         ###   ########.fr        #
+#    Updated: 2024/03/22 09:49:09 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -123,7 +123,8 @@ DEP_SUBDIRS		:=	$(sort $(dir $(DEP)))
 
 # ***************************** BUILD PROCESS ******************************** #
 
-.PHONY			:	all test run val noenv valfd build lib clean fclean re
+.PHONY			:	all test run val noenv valfd build lib clean fclean ffclean \
+					re
 
 
 #	Compilation
@@ -224,6 +225,9 @@ endif
 fclean			:	clean
 					$(MAKE) fclean -C $(LIBRARIES)
 					rm -f $(NAME)
+
+ffclean			:	fclean
+					rm -rf $(OBJ_DIR) $(DEP_DIR)
 
 re				:
 					$(MAKE) fclean


### PR DESCRIPTION
It forcefully cleans up the _obj and _dep directories in the build directory. 

When source filenames change, the build artifacts with the old filenames do not get deleted by fclean. 
This is for safety reasons so that only files known to the Makefile get deleted, and no files that might have gotten into these directories by accident.