### PR TITLE
[FIX] Fix funcheck without `-a` option

### DIFF
--- a/source/frontend/expander/expander_task_list_utils.c
+++ b/source/frontend/expander/expander_task_list_utils.c
@@ -15,6 +15,8 @@
 
 void	free_expander_task(t_expander_task *task)
 {
+	if (!task)
+		return ;
 	free(task->varname);
 	free(task);
 }

--- a/source/frontend/lexer/lexer_utils.c
+++ b/source/frontend/lexer/lexer_utils.c
@@ -52,6 +52,7 @@ bool	split_token_node(t_list *lst_node_front, size_t i)
 {
 	t_list	*lst_node_back;
 	t_token	*new_token;
+	char	*token_data_node_back;
 	char	**token_data_node_front;
 	char	**token_data_split;
 
@@ -61,10 +62,11 @@ bool	split_token_node(t_list *lst_node_front, size_t i)
 		return (false);
 	free(*token_data_node_front);
 	*token_data_node_front = token_data_split[0];
-	new_token = init_token_node(T_NONE, token_data_split[1]);
+	token_data_node_back = token_data_split[1];
 	free(token_data_split);
+	new_token = init_token_node(T_NONE, token_data_node_back);
 	if (!new_token)
-		return (free(token_data_split[1]), false);
+		return (free(token_data_node_back), false);
 	lst_node_back = ft_lstnew(new_token);
 	if (!lst_node_back)
 		return (free_token_node(new_token), false);

--- a/source/frontend/lexer/token_list.c
+++ b/source/frontend/lexer/token_list.c
@@ -24,12 +24,15 @@ bool	create_token_list(t_list **token_list, t_list **token_data_list)
 		token = init_token_node(T_NONE, (*token_data_list)->content);
 		if (!token)
 			break ;
+		(*token_data_list)->content = NULL;
 		new_nodes = ft_lstnew(token);
 		if (!new_nodes)
 			break ;
+		token = NULL;
 		if (!separate_operators(new_nodes, 0))
 			break ;
 		ft_lstadd_back(token_list, new_nodes);
+		new_nodes = NULL;
 		free(ft_lstpop_front(token_data_list));
 	}
 	if (*token_data_list)

--- a/source/frontend/parser/parser_data.c
+++ b/source/frontend/parser/parser_data.c
@@ -27,6 +27,8 @@ bool	init_parser_data(t_parser_data *parser_data, t_list *token_list)
 
 void	free_parser_data(t_parser_data *parser_data)
 {
+	if (!parser_data)
+		return ;
 	ft_lstclear(&parser_data->token_list, (void *)free_token_node);
 	ft_lstclear(&parser_data->state_stack, free);
 	ft_lstclear(&parser_data->parse_stack, (void *)free_ast_node);

--- a/source/utils/cmd_table_operation_utils.c
+++ b/source/utils/cmd_table_operation_utils.c
@@ -14,6 +14,8 @@
 
 void	free_cmd_table(t_cmd_table *cmd_table)
 {
+	if (!cmd_table)
+		return ;
 	ft_lstclear(&cmd_table->simple_cmd_list, free);
 	ft_lstclear(&cmd_table->assignment_list, free);
 	ft_lstclear(&cmd_table->io_red_list, (void *)free_io_red);

--- a/source/utils/io_redirect_utils.c
+++ b/source/utils/io_redirect_utils.c
@@ -27,6 +27,8 @@ t_io_red	*init_io_red(void)
 
 void	free_io_red(t_io_red *io_red)
 {
+	if (!io_red)
+		return ;
 	ft_free_and_null((void *)&io_red->filename);
 	ft_free_and_null((void *)&io_red->here_end);
 	ft_free_and_null((void *)&io_red);


### PR DESCRIPTION
The following cases were tested with funcheck:
```bash
echo123
echo 123
ls
```
```bash
(echo 123) | cat
```
```bash
echo < Makefile > out | (hi || ls) > out2 && this
```
```bash
echo<Makefile>out|(hi||ls)>out2&&"$USER"&&"||||"|'|'
```
```bash
"'${}'" | ${"{
```
```bash
"'${}'" | ${""}
```