### PR TITLE
[FIX] Fix heredoc for subshell redirect

### DIFF
--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -115,11 +115,6 @@ int	heredoc(t_shell *shell)
 	while (cmd_table_node && cmd_table_node->content)
 	{
 		cur_cmd_table = cmd_table_node->content;
-		if (cur_cmd_table->type != C_SIMPLE_CMD)
-		{
-			cmd_table_node = cmd_table_node->next;
-			continue ;
-		}
 		ret = handle_heredoc(
 				shell, cur_cmd_table->id, cur_cmd_table->io_red_list);
 		if (ret != HEREDOC_SUCCESS)


### PR DESCRIPTION
Since now there are also redirect lists in cmd_tables of type other than C_SIMPLE_CMD, they should not be skipped anymore when checking for heredoc io_redirect nodes.

* Resolves #274