### PR TITLE
[CHORE] Avoid misleading `ft_free_and_null()`s

### DIFF
--- a/source/shell_struct/clean.c
+++ b/source/shell_struct/clean.c
@@ -19,7 +19,7 @@ void	free_env_node(t_env *env)
 		return ;
 	ft_free_and_null((void **)&env->key);
 	ft_free_and_null((void **)&env->value);
-	ft_free_and_null((void **)&env);
+	free(env);
 }
 
 void	remove_heredoc_files(t_cmd_table *cmd_table)

--- a/source/utils/cmd_table_operation_utils.c
+++ b/source/utils/cmd_table_operation_utils.c
@@ -19,7 +19,7 @@ void	free_cmd_table(t_cmd_table *cmd_table)
 	ft_lstclear(&cmd_table->simple_cmd_list, free);
 	ft_lstclear(&cmd_table->assignment_list, free);
 	ft_lstclear(&cmd_table->io_red_list, (void *)free_io_red);
-	ft_free_and_null((void *)&cmd_table);
+	free(cmd_table);
 }
 
 t_cmd_table	*init_cmd_table(void)

--- a/source/utils/io_redirect_utils.c
+++ b/source/utils/io_redirect_utils.c
@@ -31,5 +31,5 @@ void	free_io_red(t_io_red *io_red)
 		return ;
 	ft_free_and_null((void *)&io_red->filename);
 	ft_free_and_null((void *)&io_red->here_end);
-	ft_free_and_null((void *)&io_red);
+	free(io_red);
 }

--- a/source/utils/token_utils.c
+++ b/source/utils/token_utils.c
@@ -29,7 +29,7 @@ void	free_token_node(t_token *token)
 	if (!token)
 		return ;
 	ft_free_and_null((void **)&token->data);
-	ft_free_and_null((void **)&token);
+	free(token);
 }
 
 t_token	*dup_token_node(t_token *token)


### PR DESCRIPTION
All the calls to `ft_free_and_null()` would just set the local pointer of the freeing function to NULL. 
This might give a false sense of safety that the pointer that gets put as an argument also gets set to NULL.

* These changes were made in #202.

This new PR only changes those `ft_free_and_null()`s back to `free()` that make no difference to signal interrupt behavior.