### PR TITLE
[CI] Add manually triggered norminette workflow

### DIFF
--- a/.github/actions/cleanup/action.yaml
+++ b/.github/actions/cleanup/action.yaml
@@ -1,4 +1,4 @@
-# .github/actions/cleanup/action.yml
+# .github/actions/cleanup/action.yaml
 name: Clean up forbidden files
 description: Cleanup action
 runs:

--- a/.github/actions/norminette/action.yaml
+++ b/.github/actions/norminette/action.yaml
@@ -1,4 +1,4 @@
-# .github/actions/norminette/action.yml
+# .github/actions/norminette/action.yaml
 name: Norminette Test
 description: Norminette action
 runs:

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,4 +1,4 @@
-# .github/actions/setup/action.yml
+# .github/actions/setup/action.yaml
 name: Set Up Test Environment Action
 description: Setup action
 runs:

--- a/.github/actions/summary_test_result/action.yaml
+++ b/.github/actions/summary_test_result/action.yaml
@@ -1,4 +1,4 @@
-# .github/actions/summary_test_result/action.yml
+# .github/actions/summary_test_result/action.yaml
 name: Test Result Summary Action
 description: Compares failed counts between source and target branches
 inputs:

--- a/.github/workflows/delivery.yaml
+++ b/.github/workflows/delivery.yaml
@@ -1,3 +1,4 @@
+# .github/workflows/delivery.yaml
 name: Continuous Delivery
 
 on:

--- a/.github/workflows/norminette.yaml
+++ b/.github/workflows/norminette.yaml
@@ -1,0 +1,20 @@
+# .github/workflows/norminette.yaml
+name: Norminette
+
+on:
+  workflow_dispatch:
+
+jobs:
+  norminette_test:
+    name: Norminette Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - name: Set up test environment
+        uses: ./.github/actions/setup
+      - name: 🧼 Clean up forbidden files
+        uses: ./.github/actions/cleanup
+      - name: 📏 Check norminette
+        uses: ./.github/actions/norminette

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-# .github/workflows/test.yml
+# .github/workflows/test.yaml
 name: Test Workflow
 
 on:


### PR DESCRIPTION
The branch to run the workflow on can be chosen with a drop-down menu, I think.

It's a useful option in order to not have to delete all the files locally and to quickly check norminette at any time.