### PR TITLE
[FIX] Fix wrong null-expansion after word-splitting and quote combination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/12/23 03:22:46 by ldulling          #+#    #+#              #
-#    Updated: 2024/03/22 09:49:09 by ldulling         ###   ########.fr        #
+#    Updated: 2024/03/25 18:59:05 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,6 +32,9 @@ LIB_DIR			:=	libraries
 LIBRARIES		:=	$(wildcard $(LIB_DIR)/*)
 LIBRARIES_EXT	:=	readline termcap
 INCLUDES 		:=	-I./include -I./$(LIBRARIES)/inc
+BUILDFILES		:=	Makefile \
+					$(BUILD_DIR)/parsing_table.mk \
+					$(BUILD_DIR)/source_files.mk
 
 
 #	Flags
@@ -47,17 +50,14 @@ MAKEFLAGS		:=	-j -s
 #	Macro definitions
 
 include				$(BUILD_DIR)/parsing_table.mk
-
 MACROS			:=	-D PARSING_TABLE=$(PARSING_TABLE)
 
 
 #	Test mode
 
 ifeq ($(filter test,$(MAKECMDGOALS)),test)
-
 CC 				:=	clang-12
 MACROS			+=	-D TEST_MODE=true
-
 endif
 
 
@@ -108,7 +108,6 @@ TERMINALFLAGS	:=	--title="$(TERMINALTITLE)" -- /bin/sh -c
 
 #	Files
 
-SRC				:=
 include				$(BUILD_DIR)/source_files.mk
 SRC				:=	$(addprefix $(SRC_DIR)/,$(SRC))
 OBJ 			:=	$(SRC:%.c=$(OBJ_DIR)/%.o)
@@ -159,23 +158,19 @@ else
 endif
 
 
-#		Version check for Make
+#	Version check for Make
 
 ifeq ($(firstword $(sort $(MAKE_VERSION) 4.4)),4.4)
-
 MSG_INFO		=	$(MSG_MAKE_V4.4+)
 build			:	lib .WAIT $(NAME)
-
 else
-
 MSG_INFO		=	$(MSG_MAKE_V4.3-)
 .NOTPARALLEL	:	lib
 build			:	lib $(NAME)
-
 endif
 
 
-#		Library compilation
+#	Library compilation
 
 export				MAKECMDGOALS
 
@@ -183,27 +178,27 @@ lib				:
 					$(MAKE) -C $(LIBRARIES)
 
 
-#		Executable linking
+#	Executable linking
 
 $(NAME)			:	$(LIBRARIES) $(OBJ)
 					$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
 
 
-#		Source file compiling
+#	Source file compiling
 
-$(OBJ_DIR)/%.o	:	%.c Makefile | $(OBJ_SUBDIRS)
+$(OBJ_DIR)/%.o	:	%.c $(BUILDFILES) | $(OBJ_SUBDIRS)
 					$(CC) $(CFLAGS) $(MACROS) $(INCLUDES) -c $< -o $@ \
 						&& echo -n $(MSG_PROGRESS)
 
 
-#		Pre-processing and dependency file creation
+#	Pre-processing and dependency file creation
 
-$(DEP_DIR)/%.d	:	%.c Makefile | $(DEP_SUBDIRS)
+$(DEP_DIR)/%.d	:	%.c $(BUILDFILES) | $(DEP_SUBDIRS)
 					$(CC) $(CFLAGS) $(MACROS) $(INCLUDES) \
 						-M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
 
 
-#		Mirror directory structure for build artifacts
+#	Mirror directory structure for build artifacts
 
 $(OBJ_SUBDIRS) \
 $(DEP_SUBDIRS)	:

--- a/build/source_files.mk
+++ b/build/source_files.mk
@@ -100,6 +100,7 @@ SRC		+=	$(addprefix $(SUBDIR), \
             special_param_expansion.c \
             variable_expansion.c \
             word_splitting.c \
+            word_splitting_utils.c \
 )
 #   Lexer:
 SUBDIR	:=	frontend/lexer/

--- a/build/source_files.mk
+++ b/build/source_files.mk
@@ -14,7 +14,7 @@
 # Source files:
 #  Main:
 SUBDIR	:=	./
-SRC		+=	$(addprefix $(SUBDIR), \
+SRC		:=	$(addprefix $(SUBDIR), \
             main.c \
 )
 

--- a/include/defines.h
+++ b/include/defines.h
@@ -92,7 +92,6 @@
 
 /* Symbols */
 # define QUOTES				"'\""
-# define EXPANDER_SYMBOLS	"$*\"'"
 # define OPENING_BRACE		'{'
 # define CLOSING_BRACE		'}'
 # define DOLLAR_BRACE		"${"

--- a/include/defines.h
+++ b/include/defines.h
@@ -91,6 +91,7 @@
 # define STY_RES			"\e[0m"
 
 /* Symbols */
+# define WORD_SEPERATORS	" \t\n"
 # define QUOTES				"'\""
 # define OPENING_BRACE		'{'
 # define CLOSING_BRACE		'}'
@@ -253,6 +254,7 @@ typedef struct s_token
 typedef struct s_expander_task
 {
 	t_expander_task_type	type;
+	char					**base_str;
 	int						start;
 	int						replace_len;
 	char					*varname;

--- a/include/expander.h
+++ b/include/expander.h
@@ -41,7 +41,6 @@ void			update_expander_tasks(t_list *task_list, int diff);
 int				get_offset(char *str);
 int				get_replace_len(char *str);
 void			skip_to_dollar_not_in_single_quotes(char *str, int *i);
-void			skip_to_expander_symbol(char *str, int *i);
 
 /* expansion_handler.c */
 bool			handle_expansion(t_list **lst, char **new_str, t_shell *shell,

--- a/include/expander.h
+++ b/include/expander.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/28 23:25:46 by ldulling          #+#    #+#             */
-/*   Updated: 2024/01/27 22:07:39 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/03/25 18:44:19 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,10 +23,11 @@ int				expander(char *str, t_list **lst, t_shell *shell,
 					t_expander_op op_mask);
 
 /* expander_task_list.c */
-bool			set_expander_task_list(t_list **task_list, char *new_str,
+bool			set_expander_task_list(t_list **task_list, char **base_str,
 					t_expander_op op_mask);
-bool			append_quote_task(t_list **task_list, char *new_str, int *i);
-bool			append_parameter_task(t_list **task_list, char *new_str,
+bool			append_quote_task(
+					t_list **task_list, char **base_str, int *i);
+bool			append_parameter_task(t_list **task_list, char **base_str,
 					int *i, t_expander_op op_mask);
 
 /* expander_task_list_utils.c */
@@ -35,7 +36,8 @@ char			*get_varname(char *str);
 int				get_varname_len(char *str);
 t_expander_task	*init_expander_task(t_expander_task_type type, int start,
 					int replace_len, char *str);
-void			update_expander_tasks(t_list *task_list, int diff);
+void			update_expander_tasks(t_list *task_list, int diff,
+					char **new_base_str);
 
 /* expander_utils.c */
 int				get_offset(char *str);
@@ -43,28 +45,32 @@ int				get_replace_len(char *str);
 void			skip_to_dollar_not_in_single_quotes(char *str, int *i);
 
 /* expansion_handler.c */
-bool			handle_expansion(t_list **lst, char **new_str, t_shell *shell,
+bool			handle_expansion(t_list **lst, t_shell *shell,
 					t_expander_op op_mask);
-bool			execute_expander_task_list(char **new_str, t_list *task_list,
-					t_shell *shell);
-bool			set_expanded_list(t_list **lst, char **new_str,
-					t_expander_op op_mask, t_list *task_list);
+bool			handle_parameter_expansion(t_list *task_list, t_shell *shell);
+bool			set_expanded_list(t_list **lst, t_expander_op op_mask,
+					t_list **task_list);
 
 /* null_expansion.c */
-void			check_null_expansions(t_list **lst, t_list *task_list);
+void			drop_null_expansion_nodes(t_list **lst);
 
 /* quote_removal.c */
-bool			remove_quote(char **new_str, t_list *task_list);
+bool			handle_quote_removal(t_list *task_list);
+bool			remove_quote(t_list *task_list);
 
 /* special_param_expansion.c */
-bool			expand_exit_code(char **new_str, t_list *task_list,
-					int exit_code);
+bool			expand_exit_code(t_list *task_list, int exit_code);
 
 /* variable_expansion.c */
-bool			expand_variable(char **new_str, t_list *task_list,
-					t_list *env_list);
+bool			expand_variable(t_list *task_list, t_list *env_list);
 
 /* word_splitting.c */
-bool			split_words(t_list **lst, char **new_str, t_list *task_list);
+bool			handle_word_splitting(t_list *lst, t_list **task_list);
+
+/* word_splitting_utils.c */
+char			*split_base_str(char **base_str, int *i, int *end);
+int				trim_front_whitespace(char **base_str, int *i, int *end);
+bool			append_rest_to_list(t_list **lst, t_list *task_list,
+					char *rest, int trimmed_len);
 
 #endif

--- a/include/heredoc.h
+++ b/include/heredoc.h
@@ -16,7 +16,6 @@
 # include "defines.h"
 
 int		heredoc(t_shell *shell);
-bool	is_here_end_quoted(char *here_end);
 bool	setup_tmp_hdfile(int cmdtable_id, t_io_red *io_red);
 int		expand_heredoc_content(t_shell *shell, char **content);
 bool	remove_here_end_quote(t_shell *shell,

--- a/include/utils.h
+++ b/include/utils.h
@@ -138,5 +138,6 @@ bool		skip_dollar_brace(char *str, int *i, bool is_in_dquote);
 bool		skip_double_quote(char *str, int *i);
 bool		skip_single_quote(char *str, int *i);
 char		*concat_list_to_string(t_list *list, char *delim);
+bool		is_str_quoted(char *str);
 
 #endif

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -88,7 +88,7 @@ int	handle_heredoc(t_shell *shell, int cmdtable_id, t_list *io_red_list)
 		if (io_red->type == T_HERE_DOC)
 		{
 			need_content_expansion = true;
-			if (is_here_end_quoted(io_red->here_end) && \
+			if (is_str_quoted(io_red->here_end) && \
 				!remove_here_end_quote(shell, io_red, &need_content_expansion))
 				return (HEREDOC_ERROR);
 			shell->exit_code = SUCCESS;

--- a/source/backend/redirection/heredoc_utils.c
+++ b/source/backend/redirection/heredoc_utils.c
@@ -14,13 +14,6 @@
 #include "expander.h"
 #include "signals.h"
 
-bool	is_here_end_quoted(char *here_end)
-{
-	if (ft_strchr(here_end, '\'') || ft_strchr(here_end, '\"'))
-		return (true);
-	return (false);
-}
-
 bool	setup_tmp_hdfile(int cmdtable_id, t_io_red *io_red)
 {
 	int	fd;

--- a/source/frontend/expander/expander.c
+++ b/source/frontend/expander/expander.c
@@ -23,27 +23,30 @@ int	expander(char *str, t_list **lst, t_shell *shell, t_expander_op op_mask)
 		return (MALLOC_ERROR);
 	if (is_bad_substitution(new_str, op_mask))
 		return (free(new_str), BAD_SUBSTITUTION);
-	if (!handle_expansion(lst, &new_str, shell, op_mask))
+	if (!ft_lstnew_back(lst, new_str))
 		return (free(new_str), MALLOC_ERROR);
+	if (!handle_expansion(lst, shell, op_mask))
+		return (MALLOC_ERROR);
 	return (SUCCESS);
 }
 
-bool	handle_expansion(t_list **lst, char **new_str, t_shell *shell,
-			t_expander_op op_mask)
+bool	handle_expansion(t_list **lst, t_shell *shell, t_expander_op op_mask)
 {
+	char	**base_str;
 	t_list	*task_list;
 
+	base_str = (char **)&(*lst)->content;
 	task_list = NULL;
-	if (!set_expander_task_list(&task_list, *new_str, op_mask) || \
-		!execute_expander_task_list(new_str, task_list, shell) || \
-		!set_expanded_list(lst, new_str, op_mask, task_list))
+	if (!set_expander_task_list(&task_list, base_str, op_mask) || \
+		!handle_parameter_expansion(task_list, shell) || \
+		!set_expanded_list(lst, op_mask, &task_list) || \
+		!handle_quote_removal(task_list))
 		return (ft_lstclear(&task_list, (void *)free_expander_task), false);
 	ft_lstclear(&task_list, (void *)free_expander_task);
 	return (true);
 }
 
-bool	execute_expander_task_list(
-	char **new_str, t_list *task_list, t_shell *shell)
+bool	handle_parameter_expansion(t_list *task_list, t_shell *shell)
 {
 	bool			ret;
 	t_expander_task	*task;
@@ -53,28 +56,22 @@ bool	execute_expander_task_list(
 	{
 		task = task_list->content;
 		if (task->type == ET_VAR || task->type == ET_VAR_NO_SPLIT)
-			ret = expand_variable(new_str, task_list, shell->env_list);
+			ret = expand_variable(task_list, shell->env_list);
 		else if (task->type == ET_EXIT_CODE)
-			ret = expand_exit_code(new_str, task_list, shell->exit_code);
-		else if (task->type == ET_QUOTE)
-			ret = remove_quote(new_str, task_list);
-		update_expander_tasks(
-			task_list->next, task->result_len - task->replace_len);
+			ret = expand_exit_code(task_list, shell->exit_code);
 		task_list = task_list->next;
 	}
 	return (ret);
 }
 
 bool	set_expanded_list(
-	t_list **lst, char **new_str, t_expander_op op_mask, t_list *task_list)
+	t_list **lst, t_expander_op op_mask, t_list **task_list)
 {
 	if (op_mask & E_SPLIT_WORDS)
 	{
-		if (!split_words(lst, new_str, task_list))
+		if (!handle_word_splitting(*lst, task_list))
 			return (false);
 	}
-	else if (!ft_lstnew_back(lst, *new_str))
-		return (false);
-	check_null_expansions(lst, task_list);
+	drop_null_expansion_nodes(lst);
 	return (true);
 }

--- a/source/frontend/expander/expander_task_list.c
+++ b/source/frontend/expander/expander_task_list.c
@@ -13,66 +13,68 @@
 #include "expander.h"
 #include "utils.h"
 
-bool	set_expander_task_list(t_list **task_list, char *new_str,
-			t_expander_op op_mask)
+bool	set_expander_task_list(
+	t_list **task_list, char **base_str, t_expander_op op_mask)
 {
 	int		i;
 	bool	ret;
 
 	ret = true;
 	i = 0;
-	while (new_str[i] && ret)
+	while ((*base_str)[i] && ret)
 	{
-		if (ft_strchr(QUOTES, new_str[i]) && op_mask & E_RM_QUOTES)
-			ret = append_quote_task(task_list, new_str, &i);
-		else if (new_str[i] == '$' && op_mask & E_EXPAND)
-			ret = append_parameter_task(task_list, new_str, &i, op_mask);
+		if (ft_strchr(QUOTES, (*base_str)[i]) && op_mask & E_RM_QUOTES)
+			ret = append_quote_task(task_list, base_str, &i);
+		else if ((*base_str)[i] == '$' && op_mask & E_EXPAND)
+			ret = append_parameter_task(task_list, base_str, &i, op_mask);
 		else
 			i++;
 	}
 	return (is_open_pair(0, OP_CLEAN), ret);
 }
 
-bool	append_quote_task(t_list **task_list, char *new_str, int *i)
+bool	append_quote_task(t_list **task_list, char **base_str, int *i)
 {
 	t_expander_task	*task;
 
-	if ((new_str[*i] == '"' && !is_open_pair('\'', OP_GET)) || \
-		(new_str[*i] == '\'' && !is_open_pair('"', OP_GET)))
+	if (((*base_str)[*i] == '"' && !is_open_pair('\'', OP_GET)) || \
+		((*base_str)[*i] == '\'' && !is_open_pair('"', OP_GET)))
 	{
-		task = init_expander_task(ET_QUOTE, *i, 1, &new_str[*i]);
+		task = init_expander_task(ET_QUOTE, *i, 1, &(*base_str)[*i]);
 		if (!task || !ft_lstnew_back(task_list, task))
 			return (free_expander_task(task), false);
-		is_open_pair(new_str[*i], OP_SET);
+		task->base_str = base_str;
+		is_open_pair((*base_str)[*i], OP_SET);
 	}
 	return ((*i)++, true);
 }
 
-bool	append_parameter_task(t_list **task_list, char *new_str, int *i,
-			t_expander_op op_mask)
+bool	append_parameter_task(
+	t_list **task_list, char **base_str, int *i, t_expander_op op_mask)
 {
 	int						offset;
 	int						replace_len;
 	t_expander_task			*task;
 	t_expander_task_type	type;
 
-	replace_len = get_replace_len(&new_str[*i]);
+	replace_len = get_replace_len(&(*base_str)[*i]);
 	if (is_open_pair('\'', OP_GET))
 		return (*i += replace_len, true);
-	offset = get_offset(&new_str[*i]);
-	if (is_valid_varname_start(new_str[*i + offset]))
+	offset = get_offset(&(*base_str)[*i]);
+	if (is_valid_varname_start((*base_str)[*i + offset]))
 	{
 		if (!is_open_pair('"', OP_GET) && op_mask & E_SPLIT_WORDS)
 			type = ET_VAR;
 		else
 			type = ET_VAR_NO_SPLIT;
 	}
-	else if (new_str[*i + offset] == '?')
+	else if ((*base_str)[*i + offset] == '?')
 		type = ET_EXIT_CODE;
 	else
 		return (*i += replace_len, true);
-	task = init_expander_task(type, *i, replace_len, &new_str[*i + offset]);
+	task = init_expander_task(type, *i, replace_len, &(*base_str)[*i + offset]);
 	if (!task || !ft_lstnew_back(task_list, task))
 		return (free_expander_task(task), false);
+	task->base_str = base_str;
 	return (*i += replace_len, true);
 }

--- a/source/frontend/expander/expander_task_list.c
+++ b/source/frontend/expander/expander_task_list.c
@@ -29,7 +29,6 @@ bool	set_expander_task_list(t_list **task_list, char *new_str,
 			ret = append_parameter_task(task_list, new_str, &i, op_mask);
 		else
 			i++;
-		skip_to_expander_symbol(new_str, &i);
 	}
 	return (is_open_pair(0, OP_CLEAN), ret);
 }

--- a/source/frontend/expander/expander_task_list_utils.c
+++ b/source/frontend/expander/expander_task_list_utils.c
@@ -39,8 +39,8 @@ int	get_varname_len(char *str)
 	return (len);
 }
 
-t_expander_task	*init_expander_task(t_expander_task_type type, int start,
-					int replace_len, char *str)
+t_expander_task	*init_expander_task(
+	t_expander_task_type type, int start, int replace_len, char *str)
 {
 	t_expander_task	*task;
 
@@ -48,6 +48,7 @@ t_expander_task	*init_expander_task(t_expander_task_type type, int start,
 	if (!task)
 		return (NULL);
 	task->type = type;
+	task->base_str = NULL;
 	task->start = start;
 	task->replace_len = replace_len;
 	if (type == ET_VAR || type == ET_VAR_NO_SPLIT)
@@ -58,17 +59,26 @@ t_expander_task	*init_expander_task(t_expander_task_type type, int start,
 	}
 	else
 		task->varname = NULL;
-	task->result_len = -1;
+	task->result_len = 0;
 	return (task);
 }
 
-void	update_expander_tasks(t_list *task_list, int diff)
+void	update_expander_tasks(t_list *task_list, int diff, char **new_base_str)
 {
+	char			**old_base_str;
 	t_expander_task	*task;
 
+	if (!task_list)
+		return ;
+	task = task_list->content;
+	old_base_str = task->base_str;
+	task_list = task_list->next;
 	while (task_list)
 	{
 		task = task_list->content;
+		if (task->base_str != old_base_str)
+			break ;
+		task->base_str = new_base_str;
 		task->start += diff;
 		task_list = task_list->next;
 	}

--- a/source/frontend/expander/expander_utils.c
+++ b/source/frontend/expander/expander_utils.c
@@ -61,13 +61,3 @@ void	skip_to_dollar_not_in_single_quotes(char *str, int *i)
 		(*i)++;
 	}
 }
-
-void	skip_to_expander_symbol(char *str, int *i)
-{
-	while (str[*i])
-	{
-		if (ft_strchr(EXPANDER_SYMBOLS, str[*i]))
-			return ;
-		(*i)++;
-	}
-}

--- a/source/frontend/expander/null_expansion.c
+++ b/source/frontend/expander/null_expansion.c
@@ -19,26 +19,10 @@ static bool	is_null_expansion(char *str)
 	return (false);
 }
 
-static bool	any_quote_task(t_list *task_list)
-{
-	t_expander_task	*task;
-
-	while (task_list)
-	{
-		task = task_list->content;
-		if (task->type == ET_QUOTE)
-			return (true);
-		task_list = task_list->next;
-	}
-	return (false);
-}
-
-void	check_null_expansions(t_list **lst, t_list *task_list)
+void	drop_null_expansion_nodes(t_list **lst)
 {
 	t_list	*cur;
 
-	if (any_quote_task(task_list))
-		return ;
 	cur = *lst;
 	while (cur)
 	{

--- a/source/frontend/expander/quote_removal.c
+++ b/source/frontend/expander/quote_removal.c
@@ -1,24 +1,44 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   remove_quotes.c                                    :+:      :+:    :+:   */
+/*   quote_removal.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/01 12:09:34 by ldulling          #+#    #+#             */
-/*   Updated: 2024/01/28 02:12:54 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/03/23 16:47:09 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "expander.h"
 
-bool	remove_quote(char **new_str, t_list *task_list)
+bool	handle_quote_removal(t_list *task_list)
 {
 	t_expander_task	*task;
 
+	while (task_list)
+	{
+		task = task_list->content;
+		if (task->type == ET_QUOTE)
+		{
+			if (!remove_quote(task_list))
+				return (false);
+		}
+		task_list = task_list->next;
+	}
+	return (true);
+}
+
+bool	remove_quote(t_list *task_list)
+{
+	int				diff_len;
+	t_expander_task	*task;
+
 	task = task_list->content;
-	if (!ft_strrplc_part(new_str, "", task->start, task->replace_len))
+	if (!ft_strrplc_part(task->base_str, "", task->start, task->replace_len))
 		return (false);
 	task->result_len = 0;
+	diff_len = task->result_len - task->replace_len;
+	update_expander_tasks(task_list, diff_len, task->base_str);
 	return (true);
 }

--- a/source/frontend/expander/special_param_expansion.c
+++ b/source/frontend/expander/special_param_expansion.c
@@ -1,29 +1,32 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   expand_special_param.c                             :+:      :+:    :+:   */
+/*   special_param_expansion.c                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/03 15:20:26 by ldulling          #+#    #+#             */
-/*   Updated: 2024/01/28 02:12:54 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/03/23 16:47:31 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "expander.h"
 
-bool	expand_exit_code(char **new_str, t_list *task_list, int exit_code)
+bool	expand_exit_code(t_list *task_list, int exit_code)
 {
 	char			*exit_code_str;
+	int				diff_len;
 	t_expander_task	*task;
 
 	task = task_list->content;
 	exit_code_str = ft_itoa(exit_code);
 	if (!exit_code_str)
 		return (false);
-	if (!ft_strrplc_part(new_str, exit_code_str, task->start,
-			task->replace_len))
+	if (!ft_strrplc_part(
+			task->base_str, exit_code_str, task->start, task->replace_len))
 		return (free(exit_code_str), false);
 	task->result_len = ft_strlen(exit_code_str);
+	diff_len = task->result_len - task->replace_len;
+	update_expander_tasks(task_list, diff_len, task->base_str);
 	return (free(exit_code_str), true);
 }

--- a/source/frontend/expander/variable_expansion.c
+++ b/source/frontend/expander/variable_expansion.c
@@ -1,20 +1,21 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   expand_variable.c                                  :+:      :+:    :+:   */
+/*   variable_expansion.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/03 15:18:15 by ldulling          #+#    #+#             */
-/*   Updated: 2024/01/28 02:12:54 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/03/23 16:47:34 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "expander.h"
 #include "utils.h"
 
-bool	expand_variable(char **new_str, t_list *task_list, t_list *env_list)
+bool	expand_variable(t_list *task_list, t_list *env_list)
 {
+	int				diff_len;
 	t_expander_task	*task;
 	char			*value;
 
@@ -22,9 +23,10 @@ bool	expand_variable(char **new_str, t_list *task_list, t_list *env_list)
 	value = get_value_from_env_list(env_list, task->varname);
 	if (!value)
 		value = "";
-	task->result_len = ft_strlen(value);
-	if (!ft_strrplc_part(new_str, value, task->start, task->replace_len))
+	if (!ft_strrplc_part(task->base_str, value, task->start, task->replace_len))
 		return (false);
 	task->result_len = ft_strlen(value);
+	diff_len = task->result_len - task->replace_len;
+	update_expander_tasks(task_list, diff_len, task->base_str);
 	return (true);
 }

--- a/source/frontend/expander/word_splitting.c
+++ b/source/frontend/expander/word_splitting.c
@@ -53,7 +53,7 @@ static char	*extract_word(char **new_str, t_list *task_list, int *i, int *end)
 		return (NULL);
 	trimmed_len = trim_whitespace(new_str, i, end);
 	if (trimmed_len == -1)
-		return (NULL);
+		return (free(word), NULL);
 	update_expander_tasks(task_list, 0 - ft_strlen(word) - trimmed_len);
 	return (word);
 }

--- a/source/frontend/expander/word_splitting.c
+++ b/source/frontend/expander/word_splitting.c
@@ -59,7 +59,7 @@ static char	*extract_word(char **new_str, t_list *task_list, int *i, int *end)
 }
 
 static bool	handle_word_splitting(
-	char **new_str, t_list *task_list, t_list **lst)
+	t_list **lst, char **new_str, t_list *task_list)
 {
 	int				end;
 	int				i;
@@ -96,7 +96,7 @@ bool	split_words(t_list **lst, char **new_str, t_list *task_list)
 		task = task_list->content;
 		if (task->type == ET_VAR)
 		{
-			if (!handle_word_splitting(new_str, task_list, lst))
+			if (!handle_word_splitting(lst, new_str, task_list))
 				return (false);
 		}
 		task_list = task_list->next;

--- a/source/frontend/expander/word_splitting.c
+++ b/source/frontend/expander/word_splitting.c
@@ -3,83 +3,53 @@
 /*                                                        :::      ::::::::   */
 /*   word_splitting.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 18:17:46 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/18 18:17:47 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/03/25 18:41:09 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "expander.h"
 
-static int	trim_whitespace(char **new_str, int *i, int *end)
+static bool	split_node(t_list **lst, t_list *task_list, int *i, int *end)
 {
-	int	trimmed_len;
-
-	while (ft_strchr(" \t\n", (*new_str)[*i]) && *i < *end)
-		(*i)++;
-	if (!ft_strrplc_part(new_str, "", 0, *i))
-		return (-1);
-	trimmed_len = *i;
-	*end -= trimmed_len;
-	*i = 0;
-	return (trimmed_len);
-}
-
-static char	*split(char **new_str, int *i, int *end)
-{
-	char	**halves;
-	char	*word;
-
-	halves = ft_split_at_index(*new_str, *i);
-	if (!halves)
-		return (NULL);
-	word = halves[0];
-	free(*new_str);
-	*new_str = halves[1];
-	free(halves);
-	*end -= *i;
-	*i = 0;
-	return (word);
-}
-
-static char	*extract_word(char **new_str, t_list *task_list, int *i, int *end)
-{
+	char	**base_str;
+	char	*rest;
 	int		trimmed_len;
-	char	*word;
 
-	word = split(new_str, i, end);
-	if (!word)
-		return (NULL);
-	trimmed_len = trim_whitespace(new_str, i, end);
+	base_str = (char **)&(*lst)->content;
+	rest = split_base_str(base_str, i, end);
+	if (!rest)
+		return (false);
+	trimmed_len = trim_front_whitespace(&rest, i, end);
 	if (trimmed_len == -1)
-		return (free(word), NULL);
-	update_expander_tasks(task_list, 0 - ft_strlen(word) - trimmed_len);
-	return (word);
+		return (free(rest), false);
+	trimmed_len += ft_strlen(*base_str);
+	if (!append_rest_to_list(lst, task_list, rest, trimmed_len))
+		return (free(rest), false);
+	return (true);
 }
 
-static bool	handle_word_splitting(
-	t_list **lst, char **new_str, t_list *task_list)
+static bool	split_str_into_nodes(t_list **lst, t_list *task_list)
 {
+	char			**base_str;
 	int				end;
 	int				i;
 	t_expander_task	*task;
-	char			*word;
 
+	base_str = (char **)&(*lst)->content;
 	task = task_list->content;
 	end = task->start + task->result_len;
 	i = task->start;
 	while (i < end)
 	{
-		if (ft_strchr(" \t\n", (*new_str)[i]))
+		if (ft_strchr(WORD_SEPERATORS, (*base_str)[i]))
 		{
-			word = extract_word(new_str, task_list, &i, &end);
-			if (!word)
+			if (!split_node(lst, task_list, &i, &end))
 				return (false);
-			if (!*word)
-				free(word);
-			else if (!ft_lstnew_back(lst, word))
-				return (free(word), false);
+			*lst = (*lst)->next;
+			base_str = (char **)&(*lst)->content;
 		}
 		else
 			i++;
@@ -87,19 +57,23 @@ static bool	handle_word_splitting(
 	return (true);
 }
 
-bool	split_words(t_list **lst, char **new_str, t_list *task_list)
+bool	handle_word_splitting(t_list *lst, t_list **task_list)
 {
+	t_list			*cur_task;
 	t_expander_task	*task;
 
-	while (task_list)
+	cur_task = *task_list;
+	while (cur_task)
 	{
-		task = task_list->content;
+		task = cur_task->content;
 		if (task->type == ET_VAR)
 		{
-			if (!handle_word_splitting(lst, new_str, task_list))
+			if (!split_str_into_nodes(&lst, cur_task))
 				return (false);
+			ft_lstdrop_node(task_list, &cur_task, (void *)free_expander_task);
 		}
-		task_list = task_list->next;
+		else
+			cur_task = cur_task->next;
 	}
-	return (ft_lstnew_back(lst, *new_str));
+	return (true);
 }

--- a/source/frontend/expander/word_splitting_utils.c
+++ b/source/frontend/expander/word_splitting_utils.c
@@ -1,0 +1,62 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   word_splitting_utils.c                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/03/25 18:41:12 by ldulling          #+#    #+#             */
+/*   Updated: 2024/03/25 18:43:14 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "expander.h"
+
+char	*split_base_str(char **base_str, int *i, int *end)
+{
+	char	**halves;
+	char	*rest;
+
+	halves = ft_split_at_index(*base_str, *i);
+	if (!halves)
+		return (NULL);
+	free(*base_str);
+	*base_str = halves[0];
+	rest = halves[1];
+	free(halves);
+	*end -= *i;
+	*i = 0;
+	return (rest);
+}
+
+int	trim_front_whitespace(char **base_str, int *i, int *end)
+{
+	int	trimmed_len;
+
+	while (ft_strchr(WORD_SEPERATORS, (*base_str)[*i]) && *i < *end)
+		(*i)++;
+	if (!ft_strrplc_part(base_str, "", 0, *i))
+		return (-1);
+	trimmed_len = *i;
+	*end -= trimmed_len;
+	*i = 0;
+	return (trimmed_len);
+}
+
+bool	append_rest_to_list(
+	t_list **lst, t_list *task_list, char *rest, int trimmed_len)
+{
+	char			**new_base_str;
+	t_list			*new_node;
+	t_expander_task	*task;
+
+	task = task_list->content;
+	new_node = ft_lstnew(rest);
+	if (!new_node)
+		return (false);
+	ft_lstadd_back(lst, new_node);
+	new_base_str = (char **)&new_node->content;
+	update_expander_tasks(task_list, 0 - trimmed_len, new_base_str);
+	task->base_str = new_base_str;
+	return (true);
+}

--- a/source/utils/string_utils.c
+++ b/source/utils/string_utils.c
@@ -12,7 +12,7 @@
 
 #include "utils.h"
 
-int	get_list_strlen(t_list *list, char *delim)
+static int	get_list_strlen(t_list *list, char *delim)
 {
 	int		total_length;
 	t_list	*node;
@@ -51,4 +51,11 @@ char	*concat_list_to_string(t_list *list, char *delim)
 		list = list->next;
 	}
 	return (str);
+}
+
+bool	is_str_quoted(char *str)
+{
+	if (ft_strchr(str, '\'') || ft_strchr(str, '\"'))
+		return (true);
+	return (false);
 }

--- a/todo
+++ b/todo
@@ -1,3 +1,10 @@
+# Expander
+
+- I want each each task to have a double pointer to the string that task operates on.
+	- How to update those pointers after every task execution and word split?
+
+
+
 # export:
 
 - [x] If args_len < 2, print all exported env vars in ASCII order, with "export " prepended.


### PR DESCRIPTION
- [x] First merge #282 
---
The issue was caused by too early quote removal.
Now the quotes get removed at the end of the expansion process, as is specified in the GNU Bash manual as well.

- All expander tasks now have a double pointer to the string saved in the corresponding `lst` node.
- Every entry to the expander now gets put into a `lst` node immediately.
---
* Resolves #281 