### PR TITLE
[FIX] Fix filename expansion in non-interactive mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
           done
       - name: 🔍 Check memory leaks
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh va > $HOME/leak_result.txt
         env:
           GH_BRANCH: IGNORE
@@ -97,7 +97,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: 🌱 Test source branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh m > $HOME/source_test_result.txt
         env:
           GH_BRANCH: SOURCE_FAILED_COUNT
@@ -111,7 +111,7 @@ jobs:
           ref: ${{ github.base_ref }}
       - name: 🎯 Test target branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh m > $HOME/target_test_result.txt
         env:
           GH_BRANCH: TARGET_FAILED_COUNT
@@ -135,7 +135,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: 🌱 Test source branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh b > $HOME/source_test_result.txt
         env:
           GH_BRANCH: SOURCE_FAILED_COUNT
@@ -149,7 +149,7 @@ jobs:
           ref: ${{ github.base_ref }}
       - name: 🎯 Test target branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh b > $HOME/target_test_result.txt
         env:
           GH_BRANCH: TARGET_FAILED_COUNT
@@ -173,7 +173,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: 🌱 Test source branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh ne > $HOME/source_test_result.txt
         env:
           GH_BRANCH: SOURCE_FAILED_COUNT
@@ -187,7 +187,7 @@ jobs:
           ref: ${{ github.base_ref }}
       - name: 🎯 Test target branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh ne > $HOME/target_test_result.txt
         env:
           GH_BRANCH: TARGET_FAILED_COUNT
@@ -211,7 +211,7 @@ jobs:
         uses: ./.github/actions/setup
       - name: 🌱 Test source branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh d > $HOME/source_test_result.txt
         env:
           GH_BRANCH: SOURCE_FAILED_COUNT
@@ -225,7 +225,7 @@ jobs:
           ref: ${{ github.base_ref }}
       - name: 🎯 Test target branch of pull request
         run: |
-          make fclean test
+          make re CC=clang-12
           $HOME/42_minishell_tester/tester.sh d > $HOME/target_test_result.txt
         env:
           GH_BRANCH: TARGET_FAILED_COUNT

--- a/Makefile
+++ b/Makefile
@@ -53,14 +53,6 @@ include				$(BUILD_DIR)/parsing_table.mk
 MACROS			:=	-D PARSING_TABLE=$(PARSING_TABLE)
 
 
-#	Test mode
-
-ifeq ($(filter test,$(MAKECMDGOALS)),test)
-CC 				:=	clang-12
-MACROS			+=	-D TEST_MODE=true
-endif
-
-
 #	Characters
 
 COMMA			:=	,
@@ -133,10 +125,6 @@ all				:
 						|| (echo -n $(MSG_INFO)$(MSG_START) \
 							&& ($(MAKE) build && echo $(MSG_SUCCESS)) \
 							|| (echo $(MSG_FAILURE) && exit 42))
-
-test			:
-					echo $(MSG_TEST_MODE)
-					$(MAKE) all
 
 run				:	all
 					"./$(NAME)"
@@ -258,8 +246,6 @@ MSG_SUCCESS		:=	"\e[1;3;36m\nDONE!\e[0m"
 MSG_NO_CHNG		:=	"\e[3;37mEverything up-to-date!\e[0m"
 ################################################################################
 MSG_FAILURE		:=	"\e[1;3;31mBUILD FAILED!\e[0m"
-################################################################################
-MSG_TEST_MODE	:=	"\e[1;3;4;33m-------------- TEST MODE --------------\e[0m"
 ################################################################################
 
 

--- a/include/defines.h
+++ b/include/defines.h
@@ -333,6 +333,7 @@ typedef struct s_pipe
 
 typedef struct s_shell
 {
+	bool				is_interactive;
 	pid_t				pid;
 	pid_t				subshell_pid;
 	int					subshell_level;

--- a/include/defines.h
+++ b/include/defines.h
@@ -34,10 +34,6 @@
 # include "ft_printf.h"
 # include "get_next_line.h"
 
-# ifndef TEST_MODE
-#  define TEST_MODE false
-# endif
-
 # ifndef PARSING_TABLE
 #  define DEFINITIONS_OK	false
 # else

--- a/source/backend/builtins/exit/exit.c
+++ b/source/backend/builtins/exit/exit.c
@@ -16,7 +16,7 @@
 
 void	handle_exit(t_shell *shell, int args_error)
 {
-	if (shell->subshell_level == 0 && !TEST_MODE)
+	if (shell->subshell_level == 0 && shell->is_interactive)
 		ft_dprintf(STDERR_FILENO, EXIT_MSG);
 	if (args_error == EX_TOO_MANY_ARGS)
 	{

--- a/source/backend/redirection/io_file.c
+++ b/source/backend/redirection/io_file.c
@@ -17,12 +17,15 @@
 
 int	expand_filename(t_shell *shell, char **filename)
 {
-	t_list		*expanded_list;
-	int			ret;
+	t_expander_op	op_mask;
+	t_list			*expanded_list;
+	int				ret;
 
+	op_mask = E_EXPAND | E_RM_QUOTES;
+	if (shell->is_interactive)
+		op_mask |= E_WILDCARD;
 	expanded_list = NULL;
-	ret = expander(*filename,
-			&expanded_list, shell, E_EXPAND | E_WILDCARD | E_RM_QUOTES);
+	ret = expander(*filename, &expanded_list, shell, op_mask);
 	if (ret == MALLOC_ERROR || ret == BAD_SUBSTITUTION)
 		return (ft_lstclear(&expanded_list, free), ret);
 	if (ft_lstsize_non_null(expanded_list) != 1)

--- a/source/shell_struct/init.c
+++ b/source/shell_struct/init.c
@@ -16,6 +16,7 @@
 
 bool	init_shell(t_shell *shell)
 {
+	shell->is_interactive = isatty(STDIN_FILENO);
 	shell->pid = getpid();
 	shell->subshell_pid = -1;
 	shell->subshell_level = 0;


### PR DESCRIPTION
- [x] First merge #292 

- When expanding words after redirection operators, call expander with different flags depending on the interactive mode.

- This allows to replace the test mode macro and compilation with `shell->is_interactive` variable.

* Resolves #296 