### PR TITLE
[FIX] Fix `PT_ROWS` size

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -112,8 +112,8 @@
 # define DOLLAR_BRACE		"${"
 
 /* Parsing Table */
-# define PT_COLUMNS			5
-# define PT_ROWS			192
+# define PT_COL_NUM			5
+# define PT_ROW_NUM			192
 # define UNDEFINED_STATE	-1
 
 /* Export */

--- a/include/defines.h
+++ b/include/defines.h
@@ -112,8 +112,8 @@
 # define DOLLAR_BRACE		"${"
 
 /* Parsing Table */
-# define PT_COL_SIZE		5
-# define PT_ROW_SIZE		191
+# define PT_COLUMNS			5
+# define PT_ROWS			192
 # define UNDEFINED_STATE	-1
 
 /* Export */

--- a/source/frontend/parser/parsing_table_operation.c
+++ b/source/frontend/parser/parsing_table_operation.c
@@ -17,9 +17,9 @@ static bool			match_rule(
 						int token_type,
 						int action_mask,
 						int row_index,
-						const int parsing_table[PT_ROWS][PT_COLUMNS]);
+						const int parsing_table[PT_ROW_NUM][PT_COL_NUM]);
 static t_pt_node	*init_pt_node(
-						const int pt_row[PT_ROWS]);
+						const int pt_row[PT_ROW_NUM]);
 
 bool	set_next_pt_entry(
 	t_pt_node **pt_entry,
@@ -27,11 +27,11 @@ bool	set_next_pt_entry(
 	int token_type,
 	int action_mask)
 {
-	const int	parsing_table[PT_ROWS][PT_COLUMNS] = PARSING_TABLE;
+	const int	parsing_table[PT_ROW_NUM][PT_COL_NUM] = PARSING_TABLE;
 	int			i;
 
 	i = 0;
-	while (i < PT_ROWS)
+	while (i < PT_ROW_NUM)
 	{
 		if (parsing_table[i][PT_COL_STATE] == state)
 		{
@@ -40,7 +40,7 @@ bool	set_next_pt_entry(
 		}
 		i++;
 	}
-	if (i == PT_ROWS)
+	if (i == PT_ROW_NUM)
 		return (true);
 	*pt_entry = init_pt_node(parsing_table[i]);
 	if (!*pt_entry)
@@ -52,7 +52,7 @@ static bool	match_rule(
 	int token_type,
 	int action_mask,
 	int row_index,
-	const int parsing_table[PT_ROWS][PT_COLUMNS])
+	const int parsing_table[PT_ROW_NUM][PT_COL_NUM])
 {
 	if ((action_mask & A_ACCEPT) == A_ACCEPT && \
 		parsing_table[row_index][PT_COL_ACTION] == A_ACCEPT)
@@ -72,7 +72,7 @@ static bool	match_rule(
 }
 
 static t_pt_node	*init_pt_node(
-	const int pt_row[PT_ROWS])
+	const int pt_row[PT_ROW_NUM])
 {
 	t_pt_node	*pt_node;
 

--- a/source/frontend/parser/parsing_table_operation.c
+++ b/source/frontend/parser/parsing_table_operation.c
@@ -17,9 +17,9 @@ static bool			match_rule(
 						int token_type,
 						int action_mask,
 						int row_index,
-						const int parsing_table[][PT_COL_SIZE]);
+						const int parsing_table[PT_ROWS][PT_COLUMNS]);
 static t_pt_node	*init_pt_node(
-						const int pt_row[]);
+						const int pt_row[PT_ROWS]);
 
 bool	set_next_pt_entry(
 	t_pt_node **pt_entry,
@@ -27,11 +27,11 @@ bool	set_next_pt_entry(
 	int token_type,
 	int action_mask)
 {
-	const int	parsing_table[][PT_COL_SIZE] = PARSING_TABLE;
+	const int	parsing_table[PT_ROWS][PT_COLUMNS] = PARSING_TABLE;
 	int			i;
 
 	i = 0;
-	while (i < PT_ROW_SIZE)
+	while (i < PT_ROWS)
 	{
 		if (parsing_table[i][PT_COL_STATE] == state)
 		{
@@ -40,7 +40,7 @@ bool	set_next_pt_entry(
 		}
 		i++;
 	}
-	if (i == PT_ROW_SIZE)
+	if (i == PT_ROWS)
 		return (true);
 	*pt_entry = init_pt_node(parsing_table[i]);
 	if (!*pt_entry)
@@ -52,7 +52,7 @@ static bool	match_rule(
 	int token_type,
 	int action_mask,
 	int row_index,
-	const int parsing_table[][PT_COL_SIZE])
+	const int parsing_table[PT_ROWS][PT_COLUMNS])
 {
 	if ((action_mask & A_ACCEPT) == A_ACCEPT && \
 		parsing_table[row_index][PT_COL_ACTION] == A_ACCEPT)
@@ -72,7 +72,7 @@ static bool	match_rule(
 }
 
 static t_pt_node	*init_pt_node(
-	const int pt_row[])
+	const int pt_row[PT_ROWS])
 {
 	t_pt_node	*pt_node;
 


### PR DESCRIPTION
- [x] First merge #308 
---

- The macro was one too less than the actual amount of rows of the parsing table.
  This got apparent when placing the `PT_ROW_NUM` macro into the parsing table array declarations. The compiler complained that there were excess elements in array initializer.

- Also rename the PT_ macros bc `COL_SIZE` would mean lenght of the column, but it actually stands for the amount of columns.
  Same for the rows.