### PR TITLE
[CHORE] Use enumed types whenever possible

### DIFF
--- a/build/parsing_table.mk
+++ b/build/parsing_table.mk
@@ -6,11 +6,11 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/03/30 17:50:52 by ldulling          #+#    #+#              #
-#    Updated: 2024/03/30 17:50:52 by ldulling         ###   ########.fr        #
+#    Updated: 2024/04/08 15:34:22 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-# | State | Token Type | Action | Next State | Number of Reduced Tokens |
+# | State | Element | Action | Next State | Number of Reduced Tokens |
 
 PARSING_TABLE	:=	"{\
 					{0, 0, 1, 1, -1}, \

--- a/include/builtins.h
+++ b/include/builtins.h
@@ -15,15 +15,15 @@
 
 # include "defines.h"
 
-int		exec_env(char *env[]);
-int		exec_echo(char *args[]);
-int		exec_pwd(void);
-int		exec_cd(char *args[], t_list **env_list);
-int		exec_export(char *args[], t_list **env_list);
-int		exec_unset(char *args[], t_list **env_list);
-void	exec_exit(t_sh *shell, char *args[]);
-int		exec_easter_egg(void);
+int			exec_env(char *env[]);
+int			exec_echo(char *args[]);
+int			exec_pwd(void);
+int			exec_cd(char *args[], t_list **env_list);
+int			exec_export(char *args[], t_list **env_list);
+int			exec_unset(char *args[], t_list **env_list);
+void		exec_exit(t_sh *shell, char *args[]);
+int			exec_easter_egg(void);
 
-int		get_args_error(char *args[]);
+t_exit_err	get_args_error(char *args[]);
 
 #endif

--- a/include/defines.h
+++ b/include/defines.h
@@ -319,10 +319,10 @@ typedef struct s_io_redirection
 typedef struct s_command_table
 {
 	int				id;
+	t_ct_typ		type;
 	int				subshell_level;
 	int				read_fd;
 	int				write_fd;
-	int				type;
 	t_list			*simple_cmd_list;
 	t_list			*assignment_list;
 	t_list			*io_red_list;

--- a/include/defines.h
+++ b/include/defines.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 15:56:26 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/02 23:02:09 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 17:25:12 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -170,23 +170,6 @@ typedef enum e_signal_state
 	SIG_RECORD
 }	t_sig;
 
-typedef enum e_parsing_table_column
-{
-	PT_COL_STATE	= 0,
-	PT_COL_TOKEN_TYPE,
-	PT_COL_ACTION,
-	PT_COL_NEXT_STATE,
-	PT_COL_NUM_REDUCED
-}	t_pt_col;
-
-typedef enum e_parser_action
-{
-	A_ACCEPT		= 0,
-	A_SHIFT			= 0b001,
-	A_REDUCE		= 0b010,
-	A_GOTO			= 0b100
-}	t_prs_act;
-
 typedef enum e_token_type
 {
 	T_END			= -2,
@@ -203,6 +186,55 @@ typedef enum e_token_type
 	T_L_BRACKET,
 	T_R_BRACKET
 }	t_tok_typ;
+
+typedef enum e_parsing_table_column
+{
+	PT_COL_STATE	= 0,
+	PT_COL_ELEMENT,
+	PT_COL_ACTION,
+	PT_COL_NEXT_STATE,
+	PT_COL_NUM_REDUCED
+}	t_pt_col;
+
+typedef enum e_parser_element
+{
+	P_END			= -2,
+	P_NONE			= -1,
+	P_WORD			= 0,
+	P_ASSIGNMENT_WORD,
+	P_RED_IN,
+	P_RED_OUT,
+	P_PIPE,
+	P_HERE_DOC,
+	P_APPEND,
+	P_OR,
+	P_AND,
+	P_L_BRACKET,
+	P_R_BRACKET,
+	P_AND_OR		= 100,
+	P_PIPE_SEQ,
+	P_CMD,
+	P_SUBSHELL,
+	P_SIMPLE_CMD,
+	P_CMD_NAME,
+	P_CMD_WORD,
+	P_CMD_PREFIX,
+	P_CMD_SUFFIX,
+	P_RED_LIST,
+	P_IO_RED,
+	P_IO_FILE,
+	P_FILENAME,
+	P_IO_HERE,
+	P_HERE_END
+}	t_prs_elem;
+
+typedef enum e_parser_action
+{
+	A_ACCEPT		= 0,
+	A_SHIFT			= 0b001,
+	A_REDUCE		= 0b010,
+	A_GOTO			= 0b100
+}	t_prs_act;
 
 typedef enum e_command_table_type
 {
@@ -280,7 +312,7 @@ typedef struct s_expander_task
 
 typedef struct s_abstract_syntax_tree
 {
-	int				type;
+	t_prs_elem		element;
 	char			*data;
 	t_list			*children;
 }	t_ast;
@@ -303,7 +335,7 @@ typedef struct s_parser_data
 typedef struct s_parsing_table_node
 {
 	int				state;
-	int				token_type;
+	t_prs_elem		element;
 	t_prs_act		action;
 	int				next_state;
 	int				num_reduced;

--- a/include/defines.h
+++ b/include/defines.h
@@ -304,7 +304,7 @@ typedef struct s_parsing_table_node
 {
 	int				state;
 	int				token_type;
-	int				action;
+	t_prs_act		action;
 	int				next_state;
 	int				num_reduced;
 }	t_pt_node;

--- a/include/defines.h
+++ b/include/defines.h
@@ -280,7 +280,7 @@ typedef struct s_expander_task
 
 typedef struct s_abstract_syntax_tree
 {
-	t_tok_typ		type;
+	int				type;
 	char			*data;
 	t_list			*children;
 }	t_ast;
@@ -303,7 +303,7 @@ typedef struct s_parser_data
 typedef struct s_parsing_table_node
 {
 	int				state;
-	t_tok_typ		token_type;
+	int				token_type;
 	t_prs_act		action;
 	int				next_state;
 	int				num_reduced;

--- a/include/defines.h
+++ b/include/defines.h
@@ -264,7 +264,7 @@ typedef struct s_environment_node
 
 typedef struct s_token
 {
-	int				type;
+	t_tok_typ		type;
 	char			*data;
 }	t_tok;
 
@@ -280,7 +280,7 @@ typedef struct s_expander_task
 
 typedef struct s_abstract_syntax_tree
 {
-	int				type;
+	t_tok_typ		type;
 	char			*data;
 	t_list			*children;
 }	t_ast;
@@ -303,7 +303,7 @@ typedef struct s_parser_data
 typedef struct s_parsing_table_node
 {
 	int				state;
-	int				token_type;
+	t_tok_typ		token_type;
 	t_prs_act		action;
 	int				next_state;
 	int				num_reduced;
@@ -311,7 +311,7 @@ typedef struct s_parsing_table_node
 
 typedef struct s_io_redirection
 {
-	int				type;
+	t_tok_typ		type;
 	char			*filename;
 	char			*here_end;
 }	t_io_red;

--- a/include/heredoc.h
+++ b/include/heredoc.h
@@ -15,9 +15,9 @@
 
 # include "defines.h"
 
-int		heredoc(t_sh *shell);
+t_hd_st	heredoc(t_sh *shell);
 bool	setup_tmp_hdfile(int cmdtable_id, t_io_red *io_red);
-int		expand_heredoc_content(t_sh *shell, char **content);
+t_hd_st	expand_heredoc_content(t_sh *shell, char **content);
 bool	remove_here_end_quote(t_sh *shell,
 			t_io_red *io_red, bool *need_content_expansion);
 bool	append_line_to_list(t_list **line_list, char *line);

--- a/include/parser.h
+++ b/include/parser.h
@@ -18,7 +18,7 @@
 void		report_syntax_error(t_sh *shell, t_prs_data *parser_data);
 
 bool		set_next_pt_entry(t_pt_node **pt_entry,
-				int state, int token_type, int action_mask);
+				int state, int token_type, t_prs_act action_mask);
 bool		push_state(t_list **state_stack, int next_step);
 bool		parse_shift(t_tok *input_token,
 				t_list **state_stack, t_list **parse_stack, int next_step);

--- a/include/parser.h
+++ b/include/parser.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 19:57:56 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:21:11 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 15:37:19 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,13 +18,13 @@
 void		report_syntax_error(t_sh *shell, t_prs_data *parser_data);
 
 bool		set_next_pt_entry(t_pt_node **pt_entry,
-				int state, int token_type, t_prs_act action_mask);
+				int state, t_prs_elem element, t_prs_act action_mask);
 bool		push_state(t_list **state_stack, int next_step);
 bool		parse_shift(t_tok *input_token,
 				t_list **state_stack, t_list **parse_stack, int next_step);
 bool		parse_reduce(t_list **state_stack,
 				t_list **parse_stack, t_pt_node *pt_entry);
-bool		parse_goto(t_list **state_stack, int token_type);
+bool		parse_goto(t_list **state_stack, t_prs_elem element);
 
 bool		init_parser_data(t_prs_data *parser_data, t_list *token_list);
 void		free_parser_data(t_prs_data *parser_data);

--- a/include/parser.h
+++ b/include/parser.h
@@ -18,13 +18,13 @@
 void		report_syntax_error(t_sh *shell, t_prs_data *parser_data);
 
 bool		set_next_pt_entry(t_pt_node **pt_entry,
-				int state, int token_type, t_prs_act action_mask);
+				int state, t_tok_typ token_type, t_prs_act action_mask);
 bool		push_state(t_list **state_stack, int next_step);
 bool		parse_shift(t_tok *input_token,
 				t_list **state_stack, t_list **parse_stack, int next_step);
 bool		parse_reduce(t_list **state_stack,
 				t_list **parse_stack, t_pt_node *pt_entry);
-bool		parse_goto(t_list **state_stack, int token_type);
+bool		parse_goto(t_list **state_stack, t_tok_typ token_type);
 
 bool		init_parser_data(t_prs_data *parser_data, t_list *token_list);
 void		free_parser_data(t_prs_data *parser_data);

--- a/include/parser.h
+++ b/include/parser.h
@@ -18,13 +18,13 @@
 void		report_syntax_error(t_sh *shell, t_prs_data *parser_data);
 
 bool		set_next_pt_entry(t_pt_node **pt_entry,
-				int state, t_tok_typ token_type, t_prs_act action_mask);
+				int state, int token_type, t_prs_act action_mask);
 bool		push_state(t_list **state_stack, int next_step);
 bool		parse_shift(t_tok *input_token,
 				t_list **state_stack, t_list **parse_stack, int next_step);
 bool		parse_reduce(t_list **state_stack,
 				t_list **parse_stack, t_pt_node *pt_entry);
-bool		parse_goto(t_list **state_stack, t_tok_typ token_type);
+bool		parse_goto(t_list **state_stack, int token_type);
 
 bool		init_parser_data(t_prs_data *parser_data, t_list *token_list);
 void		free_parser_data(t_prs_data *parser_data);

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/17 13:38:17 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/04 23:36:52 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 15:39:59 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ char		*get_token_data_from_list(t_list *token_list);
 t_list		*dup_token_list(t_list *token_list);
 
 /* AST utils */
-t_ast		*init_ast_node(int type, char *data, t_list *children);
+t_ast		*init_ast_node(t_prs_elem element, char *data, t_list *children);
 void		free_ast_node(t_ast *ast);
 
 /* Redirect utils */

--- a/include/utils.h
+++ b/include/utils.h
@@ -20,15 +20,15 @@ bool		read_input(char **line,
 				char *prompt, bool add_to_history, bool is_interactive);
 
 /* Token list utils */
-t_tok		*init_token_node(int type, char *data);
+t_tok		*init_token_node(t_tok_typ type, char *data);
 void		free_token_node(t_tok *token);
 t_tok		*get_token_from_list(t_list *token_list);
-int			get_token_type_from_list(t_list *token_list);
+t_tok_typ	get_token_type_from_list(t_list *token_list);
 char		*get_token_data_from_list(t_list *token_list);
 t_list		*dup_token_list(t_list *token_list);
 
 /* AST utils */
-t_ast		*init_ast_node(int type, char *data, t_list *children);
+t_ast		*init_ast_node(t_tok_typ type, char *data, t_list *children);
 void		free_ast_node(t_ast *ast);
 
 /* Redirect utils */
@@ -39,7 +39,7 @@ void		free_io_red(t_io_red *io_red);
 t_ct		*init_cmd_table(void);
 void		free_cmd_table(t_ct *cmd_table);
 bool		append_cmd_table_by_scenario(
-				int token_type, t_list_d **cmd_table_list);
+				t_tok_typ token_type, t_list_d **cmd_table_list);
 t_ct		*get_cmd_table_from_list(t_list_d *cmd_table_node);
 t_ct		*get_last_simple_cmd_table(t_list_d *cmd_table_list);
 t_ct		*get_subshell_start(t_list_d *cmd_table_node);
@@ -93,10 +93,10 @@ char		**convert_list_to_string_array(t_list *list);
 char		**append_string_array(char *array[], char *str);
 
 /* Type utils */
-bool		is_word(int token_type);
-bool		is_io_red_op(int token_type);
-bool		is_control_op(int token_type);
-bool		is_subshell_symbol(int token_type);
+bool		is_word(t_tok_typ token_type);
+bool		is_io_red_op(t_tok_typ token_type);
+bool		is_control_op(t_tok_typ token_type);
+bool		is_subshell_symbol(t_tok_typ token_type);
 
 /* File utils */
 char		*generate_tmp_filename(int cmdtable_id, char *category);

--- a/include/utils.h
+++ b/include/utils.h
@@ -43,9 +43,9 @@ bool		append_cmd_table_by_scenario(
 t_ct		*get_cmd_table_from_list(t_list_d *cmd_table_node);
 t_ct		*get_last_simple_cmd_table(t_list_d *cmd_table_list);
 t_ct		*get_subshell_start(t_list_d *cmd_table_node);
-bool		is_control_op_cmd_table(int cmd_table_type);
+bool		is_control_op_cmd_table(t_ct_typ cmd_table_type);
 bool		is_scmd_in_pipeline(t_list_d *cmd_table_node);
-int			get_cmd_table_type_from_list(t_list_d *cmd_table_list);
+t_ct_typ	get_cmd_table_type_from_list(t_list_d *cmd_table_list);
 bool		is_builtin(char *cmd_name, t_sh *shell);
 void		move_past_pipeline(t_list_d **cmd_table_node);
 void		move_past_subshell(t_list_d **cmd_table_node);

--- a/include/utils.h
+++ b/include/utils.h
@@ -28,7 +28,7 @@ char		*get_token_data_from_list(t_list *token_list);
 t_list		*dup_token_list(t_list *token_list);
 
 /* AST utils */
-t_ast		*init_ast_node(t_tok_typ type, char *data, t_list *children);
+t_ast		*init_ast_node(int type, char *data, t_list *children);
 void		free_ast_node(t_ast *ast);
 
 /* Redirect utils */

--- a/meta/gen_action_table.py
+++ b/meta/gen_action_table.py
@@ -97,7 +97,7 @@ def action_table_to_c_array(action_table):
 
 
 def action_table_to_md(action_table):
-    md_table = "| State | Token Type | Action | Next State | Number of Reduced Tokens |\n|-------|------------|--------|------------|-------------------------|\n"
+    md_table = "| State | Element | Action | Next State | Number of Reduced Tokens |\n|-------|------------|--------|------------|-------------------------|\n"
     for state, actions in action_table.items():
         for symbol, (action_type, action_state, num_reduced_tokens) in actions.items():
             md_table += f"| {state} | {symbol} | {action_type} | {action_state if action_state is not None else ''} | {num_reduced_tokens} |\n"

--- a/meta/parsing_table.md
+++ b/meta/parsing_table.md
@@ -1,4 +1,4 @@
-| State | Token Type | Action | Next State | Number of Reduced Tokens |
+| State | Element | Action | Next State | Number of Reduced Tokens |
 |-------|------------|--------|------------|-------------------------|
 | 0 | WORD | shift | 1 | -1 |
 | 0 | ASSIGNMENT_WORD | shift | 2 | -1 |

--- a/source/backend/builtins/exit/exit.c
+++ b/source/backend/builtins/exit/exit.c
@@ -13,11 +13,11 @@
 #include "builtins.h"
 #include "clean.h"
 
-static void	handle_exit(t_sh *shell, int args_error);
+static void	handle_exit(t_sh *shell, t_exit_err args_error);
 
 void	exec_exit(t_sh *shell, char *args[])
 {
-	int	args_error;
+	t_exit_err	args_error;
 
 	args_error = get_args_error(args);
 	if (args_error == EX_NORM_ARGS)
@@ -27,7 +27,7 @@ void	exec_exit(t_sh *shell, char *args[])
 	handle_exit(shell, args_error);
 }
 
-static void	handle_exit(t_sh *shell, int args_error)
+static void	handle_exit(t_sh *shell, t_exit_err args_error)
 {
 	if (shell->subshell_level == 0 && shell->is_interactive)
 		ft_dprintf(STDERR_FILENO, EXIT_MSG);

--- a/source/backend/builtins/exit/exit_utils.c
+++ b/source/backend/builtins/exit/exit_utils.c
@@ -17,18 +17,18 @@ static bool	valid_number(char *str);
 static bool	is_sign(char c);
 static bool	is_atol_overflow(char *str);
 
-int	get_args_error(char *args[])
+t_exit_err	get_args_error(char *args[])
 {
-	int	type;
+	t_exit_err	error_type;
 
 	if (!args || !args[1])
 		return (EX_NO_ARGS);
-	type = EX_NORM_ARGS;
+	error_type = EX_NORM_ARGS;
 	if (!valid_number(args[1]) || is_atol_overflow(args[1]))
-		type = EX_NOT_NUMERIC;
+		error_type = EX_NOT_NUMERIC;
 	else if (args[2])
-		type = EX_TOO_MANY_ARGS;
-	return (type);
+		error_type = EX_TOO_MANY_ARGS;
+	return (error_type);
 }
 
 static bool	valid_number(char *str)

--- a/source/backend/executor/control_operator.c
+++ b/source/backend/executor/control_operator.c
@@ -14,7 +14,7 @@
 #include "utils.h"
 #include "clean.h"
 
-static bool	should_execute_next_pipeline(t_sh *shell, int type);
+static bool	should_execute_next_pipeline(t_sh *shell, t_ct_typ type);
 static void	handle_and_or_op(t_sh *shell, t_list_d **cmd_table_node);
 
 void	handle_control_op(t_sh *shell, t_list_d **cmd_table_node)
@@ -40,7 +40,7 @@ static void	handle_and_or_op(t_sh *shell, t_list_d **cmd_table_node)
 		move_past_pipeline(cmd_table_node);
 }
 
-static bool	should_execute_next_pipeline(t_sh *shell, int type)
+static bool	should_execute_next_pipeline(t_sh *shell, t_ct_typ type)
 {
 	if (shell->signal_record != 0)
 	{

--- a/source/backend/executor/executor.c
+++ b/source/backend/executor/executor.c
@@ -21,7 +21,7 @@ static void	handle_simple_cmd(t_sh *shell, t_list_d **cmd_table_node);
 
 void	executor(t_sh *shell)
 {
-	int	heredoc_status;
+	t_hd_st	heredoc_status;
 
 	heredoc_status = heredoc(shell);
 	if (heredoc_status == HD_ERROR)

--- a/source/backend/executor/pipeline_process.c
+++ b/source/backend/executor/pipeline_process.c
@@ -48,7 +48,7 @@ void	fork_pipeline(t_sh *shell, t_list_d **cmd_table_node)
 
 static void	exec_pipeline(t_sh *shell, t_list_d **cmd_table_node)
 {
-	int	cmd_table_type;
+	t_ct_typ	cmd_table_type;
 
 	cmd_table_type = get_cmd_table_type_from_list(*cmd_table_node);
 	while (cmd_table_type == C_PIPE || \
@@ -82,7 +82,7 @@ static bool	insert_child_pid_list(t_sh *shell, pid_t pid)
 
 static void	handle_end_of_pipeline(t_sh *shell, t_list_d **cmd_table_node)
 {
-	int	cmd_table_type;
+	t_ct_typ	cmd_table_type;
 
 	cmd_table_type = get_cmd_table_type_from_list(*cmd_table_node);
 	if (is_control_op_cmd_table(cmd_table_type))

--- a/source/backend/redirection/heredoc_utils.c
+++ b/source/backend/redirection/heredoc_utils.c
@@ -32,7 +32,7 @@ bool	setup_tmp_hdfile(int cmdtable_id, t_io_red *io_red)
 	return (true);
 }
 
-int	expand_heredoc_content(t_sh *shell, char **content)
+t_hd_st	expand_heredoc_content(t_sh *shell, char **content)
 {
 	t_list	*expanded_list;
 	int		ret;
@@ -50,7 +50,7 @@ int	expand_heredoc_content(t_sh *shell, char **content)
 	if (expanded_list)
 		*content = expanded_list->content;
 	ft_lstclear(&expanded_list, NULL);
-	return (SUCCESS);
+	return (HD_SUCCESS);
 }
 
 bool	remove_here_end_quote(

--- a/source/debug/print_ast_bfs.c
+++ b/source/debug/print_ast_bfs.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/23 18:58:58 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/27 00:15:38 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 15:38:34 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -101,9 +101,9 @@ static int	print_relation_ast_node(
 		cur_level = node->level;
 	}
 	if (cur_level == 0)
-		printf("\n%d: %d ", node->level, node->current->type);
+		printf("\n%d: %d ", node->level, node->current->element);
 	else
-		printf("%d(%d) ", node->current->type, node->parent->type);
+		printf("%d(%d) ", node->current->element, node->parent->element);
 	return (cur_level);
 }
 

--- a/source/debug/print_list.c
+++ b/source/debug/print_list.c
@@ -12,7 +12,7 @@
 
 #include "debug.h"
 
-static char	*get_token_type_str(int type);
+static char	*get_token_type_str(t_tok_typ type);
 
 void	print_env_list(t_sh *shell)
 {
@@ -39,7 +39,7 @@ void	print_token(t_tok *token)
 		get_token_type_str(token->type), token->data);
 }
 
-static char	*get_token_type_str(int type)
+static char	*get_token_type_str(t_tok_typ type)
 {
 	if (type == T_WORD)
 		return ("WORD");

--- a/source/debug/print_stack.c
+++ b/source/debug/print_stack.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/17 23:56:05 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/04 22:56:50 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 15:39:23 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ void	print_parse_stack(t_list *node)
 	while (node)
 	{
 		if (get_token_from_stack(node))
-			printf("%d <- ", get_ast_from_stack(node)->type);
+			printf("%d <- ", get_ast_from_stack(node)->element);
 		node = node->next;
 	}
 	printf("(NULL)\n");

--- a/source/frontend/lexer/token_list_post_processing.c
+++ b/source/frontend/lexer/token_list_post_processing.c
@@ -23,8 +23,8 @@ void	finetune_token_list(t_list *token_list)
 
 static void	adjust_assignment_word_tokens(t_list *token_list)
 {
-	int		prev_type;
-	t_tok	*token;
+	t_tok_typ	prev_type;
+	t_tok		*token;
 
 	prev_type = T_NONE;
 	while (token_list)

--- a/source/frontend/lexer/token_type.c
+++ b/source/frontend/lexer/token_type.c
@@ -13,10 +13,10 @@
 #include "lexer.h"
 #include "utils.h"
 
-static int	which_lesser(char *token_data);
-static int	which_greater(char *token_data);
-static int	which_pipe(char *token_data);
-static bool	is_assignment_word(char *str);
+static t_tok_typ	which_lesser(char *token_data);
+static t_tok_typ	which_greater(char *token_data);
+static t_tok_typ	which_pipe(char *token_data);
+static bool			is_assignment_word(char *str);
 
 void	set_token_type(t_list *lst_node)
 {
@@ -47,7 +47,7 @@ void	set_token_type(t_list *lst_node)
 	}
 }
 
-static int	which_lesser(char *token_data)
+static t_tok_typ	which_lesser(char *token_data)
 {
 	if (ft_strcmp("<<", token_data) == 0)
 		return (T_HERE_DOC);
@@ -55,7 +55,7 @@ static int	which_lesser(char *token_data)
 		return (T_RED_IN);
 }
 
-static int	which_greater(char *token_data)
+static t_tok_typ	which_greater(char *token_data)
 {
 	if (ft_strcmp(">>", token_data) == 0)
 		return (T_APPEND);
@@ -63,7 +63,7 @@ static int	which_greater(char *token_data)
 		return (T_RED_OUT);
 }
 
-static int	which_pipe(char *token_data)
+static t_tok_typ	which_pipe(char *token_data)
 {
 	if (ft_strcmp("||", token_data) == 0)
 		return (T_OR);

--- a/source/frontend/parser/cmd_table_list.c
+++ b/source/frontend/parser/cmd_table_list.c
@@ -40,7 +40,7 @@ static bool	handle_current_token(
 	t_list **token_list,
 	t_list_d **cmd_table_list)
 {
-	int	token_type;
+	t_tok_typ	token_type;
 
 	token_type = get_token_type_from_list(*token_list);
 	if (!append_cmd_table_by_scenario(token_type, cmd_table_list))

--- a/source/frontend/parser/cmd_table_symbol.c
+++ b/source/frontend/parser/cmd_table_symbol.c
@@ -15,7 +15,7 @@
 
 bool	handle_symbol_token(t_list **token_list, t_list_d **cmd_table_list)
 {
-	int	token_type;
+	t_tok_typ	token_type;
 
 	token_type = get_token_type_from_list(*token_list);
 	if (is_io_red_op(token_type))

--- a/source/frontend/parser/cmd_table_symbol_utils.c
+++ b/source/frontend/parser/cmd_table_symbol_utils.c
@@ -12,7 +12,7 @@
 
 #include "utils.h"
 
-static bool	fill_red_node(t_io_red *io_red, int type, char *data);
+static bool	fill_red_node(t_io_red *io_red, t_tok_typ type, char *data);
 static bool	fill_redirect(t_list **token_list, t_ct *cmd_table);
 
 bool	fill_redirect_by_scenario(
@@ -87,7 +87,7 @@ static bool	fill_redirect(t_list **token_list, t_ct *cmd_table)
 	return (true);
 }
 
-static bool	fill_red_node(t_io_red *io_red, int type, char *data)
+static bool	fill_red_node(t_io_red *io_red, t_tok_typ type, char *data)
 {
 	char	*dup_data;
 

--- a/source/frontend/parser/parser.c
+++ b/source/frontend/parser/parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/11 17:28:20 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:20:11 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 15:36:42 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ static bool	parse(t_sh *shell, t_prs_data *parser_data)
 	{
 		if (!set_next_pt_entry(&pt_entry,
 				get_state_from_stack(parser_data->state_stack),
-				get_token_type_from_list(parser_data->token_list),
+				(t_prs_elem)get_token_type_from_list(parser_data->token_list),
 				A_SHIFT | A_REDUCE | A_ACCEPT))
 			(free_parser_data(parser_data),
 				clean_and_exit_shell(
@@ -77,7 +77,8 @@ static bool	parse_step(t_prs_data *parser_data, t_pt_node *pt_entry)
 		if (!(parse_reduce(&parser_data->state_stack,
 					&parser_data->parse_stack, pt_entry) && \
 			parse_goto(&parser_data->state_stack,
-					get_token_from_stack(parser_data->parse_stack)->type)))
+					(t_prs_elem)get_token_from_stack(
+						parser_data->parse_stack)->type)))
 			return (false);
 	}
 	return (true);

--- a/source/frontend/parser/parser_action.c
+++ b/source/frontend/parser/parser_action.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser_action.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/16 19:52:51 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:10:29 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 16:19:44 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,8 @@ bool	parse_shift(t_tok *token_node,
 {
 	t_ast	*ast_node;
 
-	ast_node = init_ast_node(token_node->type, token_node->data, NULL);
+	ast_node = init_ast_node(
+			(t_prs_elem)token_node->type, token_node->data, NULL);
 	free(token_node);
 	if (!ast_node)
 		return (false);
@@ -37,7 +38,7 @@ bool	parse_reduce(
 	t_list	*children;
 	t_ast	*reduce_node;
 
-	reduce_node = init_ast_node(pt_entry->next_state, NULL, NULL);
+	reduce_node = init_ast_node((t_prs_elem)pt_entry->next_state, NULL, NULL);
 	if (!reduce_node)
 		return (false);
 	if (!drop_num_stack(state_stack, pt_entry->num_reduced, free))
@@ -51,15 +52,13 @@ bool	parse_reduce(
 	return (true);
 }
 
-bool	parse_goto(t_list **state_stack, int token_type)
+bool	parse_goto(t_list **state_stack, t_prs_elem element)
 {
 	t_pt_node	*pt_entry;
 
 	pt_entry = NULL;
 	if (!set_next_pt_entry(&pt_entry,
-			get_state_from_stack(*state_stack),
-			token_type,
-			A_GOTO))
+			get_state_from_stack(*state_stack), element, A_GOTO))
 		return (false);
 	if (!pt_entry)
 		return (true);

--- a/source/frontend/parser/parser_action.c
+++ b/source/frontend/parser/parser_action.c
@@ -51,7 +51,7 @@ bool	parse_reduce(
 	return (true);
 }
 
-bool	parse_goto(t_list **state_stack, int token_type)
+bool	parse_goto(t_list **state_stack, t_tok_typ token_type)
 {
 	t_pt_node	*pt_entry;
 

--- a/source/frontend/parser/parser_action.c
+++ b/source/frontend/parser/parser_action.c
@@ -51,7 +51,7 @@ bool	parse_reduce(
 	return (true);
 }
 
-bool	parse_goto(t_list **state_stack, t_tok_typ token_type)
+bool	parse_goto(t_list **state_stack, int token_type)
 {
 	t_pt_node	*pt_entry;
 

--- a/source/frontend/parser/parsing_table_operation.c
+++ b/source/frontend/parser/parsing_table_operation.c
@@ -14,7 +14,7 @@
 #include "clean.h"
 
 static bool			match_rule(
-						t_tok_typ token_type,
+						int token_type,
 						t_prs_act action_mask,
 						int row_index,
 						const int parsing_table[PT_ROW_NUM][PT_COL_NUM]);
@@ -24,7 +24,7 @@ static t_pt_node	*init_pt_node(
 bool	set_next_pt_entry(
 	t_pt_node **pt_entry,
 	int state,
-	t_tok_typ token_type,
+	int token_type,
 	t_prs_act action_mask)
 {
 	const int	parsing_table[PT_ROW_NUM][PT_COL_NUM] = PARSING_TABLE;
@@ -49,7 +49,7 @@ bool	set_next_pt_entry(
 }
 
 static bool	match_rule(
-	t_tok_typ token_type,
+	int token_type,
 	t_prs_act action_mask,
 	int row_index,
 	const int parsing_table[PT_ROW_NUM][PT_COL_NUM])

--- a/source/frontend/parser/parsing_table_operation.c
+++ b/source/frontend/parser/parsing_table_operation.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parsing_table_operation.c                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/11 16:27:22 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:11:05 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 15:39:05 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 #include "clean.h"
 
 static bool			match_rule(
-						int token_type,
+						t_prs_elem element,
 						t_prs_act action_mask,
 						int row_index,
 						const int parsing_table[PT_ROW_NUM][PT_COL_NUM]);
@@ -24,7 +24,7 @@ static t_pt_node	*init_pt_node(
 bool	set_next_pt_entry(
 	t_pt_node **pt_entry,
 	int state,
-	int token_type,
+	t_prs_elem element,
 	t_prs_act action_mask)
 {
 	const int	parsing_table[PT_ROW_NUM][PT_COL_NUM] = PARSING_TABLE;
@@ -35,7 +35,7 @@ bool	set_next_pt_entry(
 	{
 		if (parsing_table[i][PT_COL_STATE] == state)
 		{
-			if (match_rule(token_type, action_mask, i, parsing_table))
+			if (match_rule(element, action_mask, i, parsing_table))
 				break ;
 		}
 		i++;
@@ -49,7 +49,7 @@ bool	set_next_pt_entry(
 }
 
 static bool	match_rule(
-	int token_type,
+	t_prs_elem element,
 	t_prs_act action_mask,
 	int row_index,
 	const int parsing_table[PT_ROW_NUM][PT_COL_NUM])
@@ -59,14 +59,14 @@ static bool	match_rule(
 		return (true);
 	else if ((action_mask & A_SHIFT) && \
 		parsing_table[row_index][PT_COL_ACTION] == A_SHIFT && \
-		parsing_table[row_index][PT_COL_TOKEN_TYPE] == token_type)
+		parsing_table[row_index][PT_COL_ELEMENT] == element)
 		return (true);
 	else if ((action_mask & A_REDUCE) && \
 		parsing_table[row_index][PT_COL_ACTION] == A_REDUCE)
 		return (true);
 	else if ((action_mask & A_GOTO) && \
 		parsing_table[row_index][PT_COL_ACTION] == A_GOTO && \
-		parsing_table[row_index][PT_COL_TOKEN_TYPE] == token_type)
+		parsing_table[row_index][PT_COL_ELEMENT] == element)
 		return (true);
 	return (false);
 }
@@ -80,7 +80,7 @@ static t_pt_node	*init_pt_node(
 	if (!pt_node)
 		return (NULL);
 	pt_node->state = pt_row[PT_COL_STATE];
-	pt_node->token_type = pt_row[PT_COL_TOKEN_TYPE];
+	pt_node->element = pt_row[PT_COL_ELEMENT];
 	pt_node->action = pt_row[PT_COL_ACTION];
 	pt_node->next_state = pt_row[PT_COL_NEXT_STATE];
 	pt_node->num_reduced = pt_row[PT_COL_NUM_REDUCED];

--- a/source/frontend/parser/parsing_table_operation.c
+++ b/source/frontend/parser/parsing_table_operation.c
@@ -15,7 +15,7 @@
 
 static bool			match_rule(
 						int token_type,
-						int action_mask,
+						t_prs_act action_mask,
 						int row_index,
 						const int parsing_table[PT_ROW_NUM][PT_COL_NUM]);
 static t_pt_node	*init_pt_node(
@@ -25,7 +25,7 @@ bool	set_next_pt_entry(
 	t_pt_node **pt_entry,
 	int state,
 	int token_type,
-	int action_mask)
+	t_prs_act action_mask)
 {
 	const int	parsing_table[PT_ROW_NUM][PT_COL_NUM] = PARSING_TABLE;
 	int			i;
@@ -50,7 +50,7 @@ bool	set_next_pt_entry(
 
 static bool	match_rule(
 	int token_type,
-	int action_mask,
+	t_prs_act action_mask,
 	int row_index,
 	const int parsing_table[PT_ROW_NUM][PT_COL_NUM])
 {

--- a/source/frontend/parser/parsing_table_operation.c
+++ b/source/frontend/parser/parsing_table_operation.c
@@ -14,7 +14,7 @@
 #include "clean.h"
 
 static bool			match_rule(
-						int token_type,
+						t_tok_typ token_type,
 						t_prs_act action_mask,
 						int row_index,
 						const int parsing_table[PT_ROW_NUM][PT_COL_NUM]);
@@ -24,7 +24,7 @@ static t_pt_node	*init_pt_node(
 bool	set_next_pt_entry(
 	t_pt_node **pt_entry,
 	int state,
-	int token_type,
+	t_tok_typ token_type,
 	t_prs_act action_mask)
 {
 	const int	parsing_table[PT_ROW_NUM][PT_COL_NUM] = PARSING_TABLE;
@@ -49,7 +49,7 @@ bool	set_next_pt_entry(
 }
 
 static bool	match_rule(
-	int token_type,
+	t_tok_typ token_type,
 	t_prs_act action_mask,
 	int row_index,
 	const int parsing_table[PT_ROW_NUM][PT_COL_NUM])

--- a/source/utils/ast_utils.c
+++ b/source/utils/ast_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ast_utils.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/16 19:16:10 by lyeh              #+#    #+#             */
-/*   Updated: 2023/12/28 19:46:25 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 15:39:45 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,14 +14,14 @@
 
 static void	free_ast_data(t_ast *ast);
 
-t_ast	*init_ast_node(int type, char *data, t_list *children)
+t_ast	*init_ast_node(t_prs_elem element, char *data, t_list *children)
 {
 	t_ast	*node;
 
 	node = (t_ast *)malloc(sizeof(t_ast));
 	if (!node)
 		return (NULL);
-	node->type = type;
+	node->element = element;
 	node->data = data;
 	node->children = children;
 	return (node);

--- a/source/utils/ast_utils.c
+++ b/source/utils/ast_utils.c
@@ -14,7 +14,7 @@
 
 static void	free_ast_data(t_ast *ast);
 
-t_ast	*init_ast_node(int type, char *data, t_list *children)
+t_ast	*init_ast_node(t_tok_typ type, char *data, t_list *children)
 {
 	t_ast	*node;
 

--- a/source/utils/ast_utils.c
+++ b/source/utils/ast_utils.c
@@ -14,7 +14,7 @@
 
 static void	free_ast_data(t_ast *ast);
 
-t_ast	*init_ast_node(t_tok_typ type, char *data, t_list *children)
+t_ast	*init_ast_node(int type, char *data, t_list *children)
 {
 	t_ast	*node;
 

--- a/source/utils/cmd_table_list_utils.c
+++ b/source/utils/cmd_table_list_utils.c
@@ -14,7 +14,7 @@
 
 static bool	append_empty_cmd_table(t_list_d **cmd_table_list);
 
-bool	append_cmd_table_by_scenario(int token_type, t_list_d **cmd_table_list)
+bool	append_cmd_table_by_scenario(t_tok_typ token_type, t_list_d **cmd_table_list)
 {
 	if (*cmd_table_list)
 	{

--- a/source/utils/cmd_table_list_utils.c
+++ b/source/utils/cmd_table_list_utils.c
@@ -36,8 +36,8 @@ t_ct	*get_cmd_table_from_list(t_list_d *cmd_table_node)
 
 t_ct	*get_last_simple_cmd_table(t_list_d *cmd_table_list)
 {
-	t_ct	*last_simple_cmd_table;
-	int		cur_type;
+	t_ct		*last_simple_cmd_table;
+	t_ct_typ	cur_type;
 
 	last_simple_cmd_table = NULL;
 	while (cmd_table_list && cmd_table_list->content)

--- a/source/utils/cmd_table_operation_utils.c
+++ b/source/utils/cmd_table_operation_utils.c
@@ -30,10 +30,10 @@ t_ct	*init_cmd_table(void)
 	if (!cmd_table)
 		return (NULL);
 	cmd_table->id = 0;
+	cmd_table->type = C_SIMPLE_CMD;
 	cmd_table->subshell_level = 0;
 	cmd_table->read_fd = -1;
 	cmd_table->write_fd = -1;
-	cmd_table->type = C_SIMPLE_CMD;
 	cmd_table->assignment_list = NULL;
 	cmd_table->simple_cmd_list = NULL;
 	cmd_table->io_red_list = NULL;

--- a/source/utils/cmd_table_traversal_utils.c
+++ b/source/utils/cmd_table_traversal_utils.c
@@ -32,8 +32,8 @@ void	move_past_pipeline(t_list_d **cmd_table_node)
 
 void	move_past_subshell(t_list_d **cmd_table_node)
 {
-	int	cmd_table_type;
-	int	subshell_count;
+	t_ct_typ	cmd_table_type;
+	int			subshell_count;
 
 	subshell_count = 1;
 	while (subshell_count > 0)

--- a/source/utils/cmd_table_type_utils.c
+++ b/source/utils/cmd_table_type_utils.c
@@ -13,7 +13,7 @@
 #include "utils.h"
 #include "expander.h"
 
-bool	is_control_op_cmd_table(int cmd_table_type)
+bool	is_control_op_cmd_table(t_ct_typ cmd_table_type)
 {
 	return (cmd_table_type == C_AND || cmd_table_type == C_OR || \
 		cmd_table_type == C_PIPE);
@@ -32,7 +32,7 @@ bool	is_scmd_in_pipeline(t_list_d *cmd_table_node)
 	return (false);
 }
 
-int	get_cmd_table_type_from_list(t_list_d *cmd_table_list)
+t_ct_typ	get_cmd_table_type_from_list(t_list_d *cmd_table_list)
 {
 	t_ct	*cmd_table;
 

--- a/source/utils/token_status_utils.c
+++ b/source/utils/token_status_utils.c
@@ -19,7 +19,7 @@ t_tok	*get_token_from_list(t_list *token_list)
 	return ((t_tok *)token_list->content);
 }
 
-int	get_token_type_from_list(t_list *token_list)
+t_tok_typ	get_token_type_from_list(t_list *token_list)
 {
 	if (!token_list)
 		return (T_NONE);

--- a/source/utils/token_type_utils.c
+++ b/source/utils/token_type_utils.c
@@ -12,23 +12,23 @@
 
 #include "defines.h"
 
-bool	is_word(int token_type)
+bool	is_word(t_tok_typ token_type)
 {
 	return (token_type == T_WORD || token_type == T_ASSIGNMENT_WORD);
 }
 
-bool	is_io_red_op(int token_type)
+bool	is_io_red_op(t_tok_typ token_type)
 {
 	return (token_type == T_HERE_DOC || token_type == T_APPEND || \
 		token_type == T_RED_IN || token_type == T_RED_OUT);
 }
 
-bool	is_control_op(int token_type)
+bool	is_control_op(t_tok_typ token_type)
 {
 	return (token_type == T_AND || token_type == T_OR || token_type == T_PIPE);
 }
 
-bool	is_subshell_symbol(int token_type)
+bool	is_subshell_symbol(t_tok_typ token_type)
 {
 	return (token_type == T_L_BRACKET || token_type == T_R_BRACKET);
 }

--- a/source/utils/token_utils.c
+++ b/source/utils/token_utils.c
@@ -14,7 +14,7 @@
 
 static t_tok	*dup_token_node(t_tok *token);
 
-t_tok	*init_token_node(int type, char *data)
+t_tok	*init_token_node(t_tok_typ type, char *data)
 {
 	t_tok	*token_node;
 


### PR DESCRIPTION
- It allows the compiler to enforce that only values from this enum are passed to functions, which helps to prevent errors from the programmer.

- It also shows the enum names in the debugger, which makes it easier to debug than just seeing the integers.

