### PR TITLE
[STYLE] Rename `token_node` to `token` when not a `t_list`

### DIFF
--- a/include/lexer.h
+++ b/include/lexer.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 10:35:51 by ldulling          #+#    #+#             */
-/*   Updated: 2024/03/19 15:52:15 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 12:44:36 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ bool	lexer(t_sh *shell);
 bool	is_operator(char *token_data);
 void	print_missing_pair_error(char *str);
 void	skip_operator(char *token_data, int *i);
-bool	split_token_node(t_list *lst_node_front, int i);
+bool	split_token_node(t_list *node_front, int i);
 
 /* token_data_list.c */
 bool	create_token_data_list(t_list **token_data_list, char *input_line);
@@ -35,6 +35,6 @@ bool	append_end_node(t_list	**token_list);
 void	finetune_token_list(t_list *token_list);
 
 /* token_type.c */
-void	set_token_type(t_list *lst_node);
+void	set_token_type(t_list *token_list);
 
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -19,7 +19,7 @@ void		report_syntax_error(t_sh *shell, t_prs_data *parser_data);
 
 bool		set_next_pt_entry(t_pt_node **pt_entry,
 				int state, t_prs_elem element, t_prs_act action_mask);
-bool		push_state(t_list **state_stack, int next_state);
+bool		push_state(t_list **state_stack, int state);
 bool		parse_shift(t_tok *input_token,
 				t_list **state_stack, t_list **parse_stack, int next_state);
 bool		parse_reduce(t_list **state_stack,

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 19:57:56 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/08 17:47:13 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 18:03:38 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@ void		report_syntax_error(t_sh *shell, t_prs_data *parser_data);
 bool		set_next_pt_entry(t_pt_node **pt_entry,
 				int state, t_prs_elem element, t_prs_act action_mask);
 bool		push_state(t_list **state_stack, int state);
-bool		parse_shift(t_tok *input_token,
+bool		parse_shift(t_tok *token,
 				t_list **state_stack, t_list **parse_stack, int next_state);
 bool		parse_reduce(t_list **state_stack,
 				t_list **parse_stack, t_pt_node *pt_entry);

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/17 13:38:17 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/08 15:39:59 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 18:03:51 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,8 @@ bool		read_input(char **line,
 				char *prompt, bool add_to_history, bool is_interactive);
 
 /* Token list utils */
-t_tok		*init_token_node(t_tok_typ type, char *data);
-void		free_token_node(t_tok *token);
+t_tok		*init_token(t_tok_typ type, char *data);
+void		free_token(t_tok *token);
 t_tok		*get_token_from_list(t_list *token_list);
 t_tok_typ	get_token_type_from_list(t_list *token_list);
 char		*get_token_data_from_list(t_list *token_list);

--- a/source/frontend/lexer/lexer_utils.c
+++ b/source/frontend/lexer/lexer_utils.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 10:33:59 by ldulling          #+#    #+#             */
-/*   Updated: 2024/04/08 12:33:26 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 12:41:05 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,15 +48,15 @@ void	skip_operator(char *token_data, int *i)
 		(*i)++;
 }
 
-bool	split_token_node(t_list *lst_node_front, int i)
+bool	split_token_node(t_list *node_front, int i)
 {
-	t_list	*lst_node_back;
 	t_tok	*new_token;
+	t_list	*node_back;
 	char	*token_data_node_back;
 	char	**token_data_node_front;
 	char	**token_data_split;
 
-	token_data_node_front = &((t_tok *)lst_node_front->content)->data;
+	token_data_node_front = &((t_tok *)node_front->content)->data;
 	token_data_split = ft_split_at_index(*token_data_node_front, i);
 	if (!token_data_split)
 		return (false);
@@ -67,9 +67,9 @@ bool	split_token_node(t_list *lst_node_front, int i)
 	new_token = init_token(T_NONE, token_data_node_back);
 	if (!new_token)
 		return (free(token_data_node_back), false);
-	lst_node_back = ft_lstnew(new_token);
-	if (!lst_node_back)
-	ft_lstinsert_after(&lst_node_front, lst_node_back);
+	node_back = ft_lstnew(new_token);
+	if (!node_back)
 		return (free_token(new_token), false);
+	ft_lstinsert_after(&node_front, node_back);
 	return (true);
 }

--- a/source/frontend/lexer/lexer_utils.c
+++ b/source/frontend/lexer/lexer_utils.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 10:33:59 by ldulling          #+#    #+#             */
-/*   Updated: 2024/03/19 15:52:40 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 12:33:26 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,12 +64,12 @@ bool	split_token_node(t_list *lst_node_front, int i)
 	*token_data_node_front = token_data_split[0];
 	token_data_node_back = token_data_split[1];
 	free(token_data_split);
-	new_token = init_token_node(T_NONE, token_data_node_back);
+	new_token = init_token(T_NONE, token_data_node_back);
 	if (!new_token)
 		return (free(token_data_node_back), false);
 	lst_node_back = ft_lstnew(new_token);
 	if (!lst_node_back)
-		return (free_token_node(new_token), false);
 	ft_lstinsert_after(&lst_node_front, lst_node_back);
+		return (free_token(new_token), false);
 	return (true);
 }

--- a/source/frontend/lexer/token_list.c
+++ b/source/frontend/lexer/token_list.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 11:54:32 by ldulling          #+#    #+#             */
-/*   Updated: 2024/04/08 12:28:05 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 12:43:37 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,10 @@
 #include "utils.h"
 
 static bool	separate_operators(
-				t_list *lst_node,
+				t_list *token_node,
 				int i);
 static bool	split_and_advance_node(
-				t_list **lst_node,
+				t_list **token_node,
 				char **token_data,
 				int *i);
 
@@ -63,12 +63,12 @@ bool	append_end_node(
 }
 
 static bool	separate_operators(
-	t_list *lst_node,
+	t_list *token_node,
 	int i)
 {
 	char	*token_data;
 
-	token_data = get_token_data_from_list(lst_node);
+	token_data = get_token_data_from_list(token_node);
 	while (token_data[i])
 	{
 		if (token_data[i] == '\'')
@@ -79,7 +79,7 @@ static bool	separate_operators(
 			skip_dollar_brace(token_data, &i, false);
 		else if (is_operator(&token_data[i]))
 		{
-			if (!split_and_advance_node(&lst_node, &token_data, &i))
+			if (!split_and_advance_node(&token_node, &token_data, &i))
 				return (false);
 			continue ;
 		}
@@ -89,7 +89,7 @@ static bool	separate_operators(
 }
 
 static bool	split_and_advance_node(
-	t_list **lst_node,
+	t_list **token_node,
 	char **token_data,
 	int *i)
 {
@@ -97,10 +97,10 @@ static bool	split_and_advance_node(
 		skip_operator(*token_data, i);
 	if ((*token_data)[*i])
 	{
-		if (!split_token_node(*lst_node, *i))
+		if (!split_token_node(*token_node, *i))
 			return (false);
-		*lst_node = (*lst_node)->next;
-		*token_data = get_token_data_from_list(*lst_node);
+		*token_node = (*token_node)->next;
+		*token_data = get_token_data_from_list(*token_node);
 		*i = 0;
 	}
 	return (true);

--- a/source/frontend/lexer/token_list.c
+++ b/source/frontend/lexer/token_list.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   token_list.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/20 11:54:32 by ldulling          #+#    #+#             */
-/*   Updated: 2024/03/21 17:17:46 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 12:28:05 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ bool	create_token_list(
 	new_nodes = NULL;
 	while (*token_data_list)
 	{
-		token = init_token_node(T_NONE, (*token_data_list)->content);
+		token = init_token(T_NONE, (*token_data_list)->content);
 		if (!token)
 			break ;
 		(*token_data_list)->content = NULL;
@@ -46,8 +46,8 @@ bool	create_token_list(
 		free(ft_lstpop_front(token_data_list));
 	}
 	if (*token_data_list)
-		return (free_token_node(token), \
-				ft_lstclear(&new_nodes, (void *)free_token_node), false);
+		return (free_token(token),
+			ft_lstclear(&new_nodes, (void *)free_token), false);
 	return (true);
 }
 
@@ -56,9 +56,9 @@ bool	append_end_node(
 {
 	t_tok	*token;
 
-	token = init_token_node(T_END, NULL);
+	token = init_token(T_END, NULL);
 	if (!token || !ft_lstnew_back(token_list, token))
-		return (free_token_node(token), false);
+		return (free_token(token), false);
 	return (true);
 }
 

--- a/source/frontend/lexer/token_type.c
+++ b/source/frontend/lexer/token_type.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   token_type.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/21 16:20:32 by ldulling          #+#    #+#             */
-/*   Updated: 2024/03/21 17:17:47 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 12:44:36 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,14 +18,14 @@ static t_tok_typ	which_greater(char *token_data);
 static t_tok_typ	which_pipe(char *token_data);
 static bool			is_assignment_word(char *str);
 
-void	set_token_type(t_list *lst_node)
+void	set_token_type(t_list *token_list)
 {
 	t_tok	*token;
 	char	*token_data;
 
-	while (lst_node)
+	while (token_list)
 	{
-		token = (t_tok *)lst_node->content;
+		token = (t_tok *)token_list->content;
 		token_data = token->data;
 		if (*token_data == '<')
 			token->type = which_lesser(token_data);
@@ -43,7 +43,7 @@ void	set_token_type(t_list *lst_node)
 			token->type = T_ASSIGNMENT_WORD;
 		else
 			token->type = T_WORD;
-		lst_node = lst_node->next;
+		token_list = token_list->next;
 	}
 }
 

--- a/source/frontend/parser/parser.c
+++ b/source/frontend/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/11 17:28:20 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/08 15:36:42 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 18:04:43 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ bool	parser(t_sh *shell)
 	if (!shell->cmd_table_list)
 		clean_and_exit_shell(
 			shell, PREPROCESS_ERROR, "build cmd table malloc failed");
-	ft_lstclear(&shell->token_list, (void *)free_token_node);
+	ft_lstclear(&shell->token_list, (void *)free_token);
 	return (true);
 }
 

--- a/source/frontend/parser/parser_action.c
+++ b/source/frontend/parser/parser_action.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/16 19:52:51 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/08 16:19:44 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 18:04:31 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,14 +15,13 @@
 
 static bool	push_node(t_list **parse_stack, t_ast *ast_node);
 
-bool	parse_shift(t_tok *token_node,
-	t_list **state_stack, t_list **parse_stack, int next_state)
+bool	parse_shift(
+	t_tok *token, t_list **state_stack, t_list **parse_stack, int next_state)
 {
 	t_ast	*ast_node;
 
-	ast_node = init_ast_node(
-			(t_prs_elem)token_node->type, token_node->data, NULL);
-	free(token_node);
+	ast_node = init_ast_node((t_prs_elem)token->type, token->data, NULL);
+	free(token);
 	if (!ast_node)
 		return (false);
 	if (!push_node(parse_stack, ast_node))

--- a/source/frontend/parser/parser_data.c
+++ b/source/frontend/parser/parser_data.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser_data.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/16 22:05:05 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:11:03 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 12:27:27 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ void	free_parser_data(t_prs_data *parser_data)
 {
 	if (!parser_data)
 		return ;
-	ft_lstclear(&parser_data->token_list, (void *)free_token_node);
+	ft_lstclear(&parser_data->token_list, (void *)free_token);
 	ft_lstclear(&parser_data->state_stack, NULL);
 	ft_lstclear(&parser_data->parse_stack, (void *)free_ast_node);
 }

--- a/source/shell/clean.c
+++ b/source/shell/clean.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   clean.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 19:02:15 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:36:38 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/04/08 12:27:27 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ static void	clean_shell(t_sh *shell)
 	ft_free_and_null((void **)&shell->input_line);
 	ft_lstclear(&shell->child_pid_list, NULL);
 	ft_lstclear(&shell->env_list, (void *)free_env_node);
-	ft_lstclear(&shell->token_list, (void *)free_token_node);
+	ft_lstclear(&shell->token_list, (void *)free_token);
 	if (shell->subshell_level == 0)
 		ft_lstiter_d(shell->cmd_table_list, (void *)remove_heredoc_files);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);
@@ -46,7 +46,7 @@ void	reset_submodule_variable(t_sh *shell)
 	shell->subshell_pid = -1;
 	shell->signal_record = 0;
 	ft_lstclear(&shell->child_pid_list, NULL);
-	ft_lstclear(&shell->token_list, (void *)free_token_node);
+	ft_lstclear(&shell->token_list, (void *)free_token);
 	ft_lstiter_d(shell->cmd_table_list, (void *)remove_heredoc_files);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);
 	ft_free_and_null((void **)&shell->input_line);

--- a/source/utils/token_utils.c
+++ b/source/utils/token_utils.c
@@ -6,27 +6,27 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/16 22:01:28 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/04 23:35:25 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/04/08 12:27:27 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "utils.h"
 
-static t_tok	*dup_token_node(t_tok *token);
+static t_tok	*dup_token(t_tok *token);
 
-t_tok	*init_token_node(t_tok_typ type, char *data)
+t_tok	*init_token(t_tok_typ type, char *data)
 {
-	t_tok	*token_node;
+	t_tok	*token;
 
-	token_node = (t_tok *)malloc(sizeof(t_tok));
-	if (!token_node)
+	token = (t_tok *)malloc(sizeof(t_tok));
+	if (!token)
 		return (NULL);
-	token_node->type = type;
-	token_node->data = data;
-	return (token_node);
+	token->type = type;
+	token->data = data;
+	return (token);
 }
 
-void	free_token_node(t_tok *token)
+void	free_token(t_tok *token)
 {
 	if (!token)
 		return ;
@@ -42,11 +42,11 @@ t_list	*dup_token_list(t_list *token_list)
 	dup_list = NULL;
 	while (token_list)
 	{
-		token = dup_token_node(token_list->content);
+		token = dup_token(token_list->content);
 		if (!token || !ft_lstnew_back(&dup_list, token))
 		{
-			free_token_node(token);
-			ft_lstclear(&dup_list, (void *)free_token_node);
+			free_token(token);
+			ft_lstclear(&dup_list, (void *)free_token);
 			return (NULL);
 		}
 		token_list = token_list->next;
@@ -54,7 +54,7 @@ t_list	*dup_token_list(t_list *token_list)
 	return (dup_list);
 }
 
-static t_tok	*dup_token_node(t_tok *token)
+static t_tok	*dup_token(t_tok *token)
 {
 	t_tok	*dup_token;
 	char	*dup_data;
@@ -66,7 +66,7 @@ static t_tok	*dup_token_node(t_tok *token)
 		if (!dup_data)
 			return (NULL);
 	}
-	dup_token = init_token_node(token->type, dup_data);
+	dup_token = init_token(token->type, dup_data);
 	if (!dup_token)
 		return (free(dup_data), NULL);
 	return (dup_token);


### PR DESCRIPTION
- [x] First merge #313.

---

`node` should be a `t_list`, just `token` a `t_tok`.

* Resolves #52 