### PR TITLE
[STYLE] Make function signatures consistent

### DIFF
--- a/include/cd.h
+++ b/include/cd.h
@@ -26,8 +26,8 @@ bool		is_abs_path(char *path);
 /* cmpnt_list.c */
 t_list_d	*get_abs_path_cmpnt_list(char *pwd, char *target_dir);
 t_list_d	*create_cmpnt_list(char *path);
-char		*convert_cmpnt_node_to_path(t_list_d *cmpnt_list,
-				t_list_d *cmpnt_node);
+char		*convert_cmpnt_node_to_path(
+				t_list_d *cmpnt_list, t_list_d *cmpnt_node);
 
 /* cmpnt_list_utils.c */
 int			check_cmpnt_node_path(

--- a/include/executor.h
+++ b/include/executor.h
@@ -18,8 +18,7 @@
 void	executor(t_sh *shell);
 int		set_expanded_cmd_name(
 			char **cmd_name, t_sh *shell, t_list *simple_cmd_list);
-void	handle_expansion_error(
-			t_sh *shell, t_list_d **cmd_table_node, int ret);
+void	handle_expansion_error(t_sh *shell, t_list_d **cmd_table_node, int ret);
 
 void	handle_process(t_sh *shell, t_list_d *cmd_table_node);
 void	fork_subshell(t_sh *shell, t_list_d **cmd_table_node);

--- a/include/expander.h
+++ b/include/expander.h
@@ -27,23 +27,21 @@ int			expander(
 
 /* expander_task_list.c */
 bool		set_expander_task_list(
-				t_list **task_list,
-				char **base_str,
-				t_expd_op op_mask);
+				t_list **task_list, char **base_str, t_expd_op op_mask);
 
 /* expander_task_list_utils.c */
 bool		any_task_of_type(t_list *task_list, t_expd_tsk_typ type);
-void		drop_task_types(t_list **task_list, char **word,
-				t_expd_tsk_typ type);
-t_list		*get_expander_task_node(t_list *task_list, char **base_str,
-				int i, t_expd_tsk_typ type);
-void		update_expander_tasks(t_list *task_list, int diff,
-				char **new_base_str);
+void		drop_task_types(
+				t_list **task_list, char **word, t_expd_tsk_typ type);
+t_list		*get_expander_task_node(
+				t_list *task_list, char **base_str, int i, t_expd_tsk_typ type);
+void		update_expander_tasks(
+				t_list *task_list, int diff, char **new_base_str);
 
 /* expander_task_utils.c */
 void		free_expander_task(t_expd_tsk *task);
-t_expd_tsk	*init_expander_task(t_expd_tsk_typ type, int start,
-				int replace_len, char *str);
+t_expd_tsk	*init_expander_task(
+				t_expd_tsk_typ type, int start, int replace_len, char *str);
 
 /* expander_utils.c */
 int			get_offset(char *str);
@@ -62,8 +60,7 @@ bool		handle_quote_removal(t_list **task_list);
 
 /* wildcard_expansion.c */
 bool		handle_wildcard_expansion(
-				t_list **expanded_list,
-				t_list **task_list);
+				t_list **expanded_list, t_list **task_list);
 
 /* wildcard_expansion_utils.c */
 bool		is_wildcard(char *word, t_list *task_list);
@@ -76,20 +73,19 @@ void		sort_file_list(t_list **file_list);
 
 /* wildcard_task_list.c */
 bool		set_wildcard_task_list(
-				t_list **task_list,
-				t_list *expanded_list,
-				t_expd_op op_mask);
+				t_list **task_list, t_list *expanded_list, t_expd_op op_mask);
 
 /* word_splitting.c */
 bool		handle_word_splitting(
-				t_list **expanded_list,
-				t_expd_op op_mask,
-				t_list **task_list);
+				t_list **expanded_list, t_expd_op op_mask, t_list **task_list);
 
 /* word_splitting_utils.c */
 char		*split_base_str(char **base_str, int *i, int *end);
 int			trim_front_whitespace(char **base_str, int *i, int *end);
-bool		append_rest_to_list(t_list **expanded_list, t_list *task_node,
-				char *rest, int trimmed_len);
+bool		append_rest_to_list(
+				t_list **expanded_list,
+				t_list *task_node,
+				char *rest,
+				int trimmed_len);
 
 #endif

--- a/include/heredoc.h
+++ b/include/heredoc.h
@@ -18,8 +18,8 @@
 t_hd_st	heredoc(t_sh *shell);
 bool	setup_tmp_hdfile(int cmdtable_id, t_io_red *io_red);
 t_hd_st	expand_heredoc_content(t_sh *shell, char **content);
-bool	remove_here_end_quote(t_sh *shell,
-			t_io_red *io_red, bool *need_content_expansion);
+bool	remove_here_end_quote(
+			t_sh *shell, t_io_red *io_red, bool *need_content_expansion);
 bool	append_line_to_list(t_list **line_list, char *line);
 bool	is_str_quoted(char *str);
 char	*concat_list_to_string(t_list *list, char *delim);

--- a/include/parser.h
+++ b/include/parser.h
@@ -17,13 +17,21 @@
 
 void		report_syntax_error(t_sh *shell, t_prs_data *parser_data);
 
-bool		set_next_pt_entry(t_pt_node **pt_entry,
-				int state, t_prs_elem element, t_prs_act action_mask);
+bool		set_next_pt_entry(
+				t_pt_node **pt_entry,
+				int state,
+				t_prs_elem element,
+				t_prs_act action_mask);
 bool		push_state(t_list **state_stack, int state);
-bool		parse_shift(t_tok *token,
-				t_list **state_stack, t_list **parse_stack, int next_state);
-bool		parse_reduce(t_list **state_stack,
-				t_list **parse_stack, t_pt_node *pt_entry);
+bool		parse_shift(
+				t_tok *token,
+				t_list **state_stack,
+				t_list **parse_stack,
+				int next_state);
+bool		parse_reduce(
+				t_list **state_stack,
+				t_list **parse_stack,
+				t_pt_node *pt_entry);
 bool		parse_goto(t_list **state_stack, t_prs_elem element);
 
 bool		init_parser_data(t_prs_data *parser_data, t_list *token_list);

--- a/include/utils.h
+++ b/include/utils.h
@@ -16,8 +16,11 @@
 # include "defines.h"
 
 /* User input utils */
-bool		read_input(char **line,
-				char *prompt, bool add_to_history, bool is_interactive);
+bool		read_input(
+				char **line,
+				char *prompt,
+				bool add_to_history,
+				bool is_interactive);
 
 /* Token list utils */
 t_tok		*init_token(t_tok_typ type, char *data);
@@ -57,10 +60,9 @@ bool		setup_exec_path(t_sh *shell, t_fct *final_cmd_table);
 int			setup_simple_cmd(t_sh *shell, t_list *simple_cmd_list);
 bool		setup_env(t_fct *final_cmd_table, t_list *env_list);
 bool		set_exec_path(char **exec_path, char *cmd_name, char *env[]);
-bool		setup_assignment_array(t_fct *final_cmd_table,
-				t_list *assignment_list);
-void		setup_fd(
-				t_sh *shell, t_fct *final_cmd_table);
+bool		setup_assignment_array(
+				t_fct *final_cmd_table, t_list *assignment_list);
+void		setup_fd(t_sh *shell, t_fct *final_cmd_table);
 
 /* Environment utils */
 bool		extract_env_key(char **res, const char *str);
@@ -83,8 +85,11 @@ bool		replace_env_value(
 				t_list *env_list, char *key, char *value, char **old_value);
 
 /* Expansion utils */
-int			expand_list(t_sh *shell, t_list *list, t_list **expanded_list, \
-						t_expd_op op_mask);
+int			expand_list(
+				t_sh *shell,
+				t_list *list,
+				t_list **expanded_list,
+				t_expd_op op_mask);
 
 /* Array utils */
 void		free_array(char **array[]);

--- a/source/backend/builtins/cd/component_list.c
+++ b/source/backend/builtins/cd/component_list.c
@@ -12,18 +12,14 @@
 
 #include "cd.h"
 
-static bool	create_root_cmpnt_nodes(
-				t_list_d **cmpnt_list,
-				char *path);
+static bool	create_root_cmpnt_nodes(t_list_d **cmpnt_list, char *path);
 static void	convert_root_cmpnt_nodes_to_path(
 				t_list_d **cmpnt_list,
 				t_list_d *cmpnt_node,
 				char *path,
 				int *i);
 
-t_list_d	*get_abs_path_cmpnt_list(
-	char *pwd,
-	char *target_dir)
+t_list_d	*get_abs_path_cmpnt_list(char *pwd, char *target_dir)
 {
 	t_list_d	*cmpnt_list;
 	t_list_d	*tmp_list;
@@ -45,8 +41,7 @@ t_list_d	*get_abs_path_cmpnt_list(
 	return (cmpnt_list);
 }
 
-t_list_d	*create_cmpnt_list(
-	char *path)
+t_list_d	*create_cmpnt_list(char *path)
 {
 	char		*cmpnt;
 	t_list_d	*cmpnt_list;
@@ -71,9 +66,7 @@ t_list_d	*create_cmpnt_list(
 	return (free(path), cmpnt_list);
 }
 
-static bool	create_root_cmpnt_nodes(
-	t_list_d **cmpnt_list,
-	char *path)
+static bool	create_root_cmpnt_nodes(t_list_d **cmpnt_list, char *path)
 {
 	char	*tmp;
 
@@ -90,8 +83,7 @@ static bool	create_root_cmpnt_nodes(
 }
 
 char	*convert_cmpnt_node_to_path(
-	t_list_d *cmpnt_list,
-	t_list_d *cmpnt_node)
+			t_list_d *cmpnt_list, t_list_d *cmpnt_node)
 {
 	int		i;
 	int		len;
@@ -117,10 +109,10 @@ char	*convert_cmpnt_node_to_path(
 }
 
 static void	convert_root_cmpnt_nodes_to_path(
-	t_list_d **cmpnt_list,
-	t_list_d *cmpnt_node,
-	char *path,
-	int *i)
+				t_list_d **cmpnt_list,
+				t_list_d *cmpnt_node,
+				char *path,
+				int *i)
 {
 	while (*cmpnt_list && (*cmpnt_list)->prev != cmpnt_node && \
 		is_root_cmpnt_node(*cmpnt_list))

--- a/source/backend/builtins/cd/component_list_utils.c
+++ b/source/backend/builtins/cd/component_list_utils.c
@@ -13,7 +13,7 @@
 #include "cd.h"
 
 int	check_cmpnt_node_path(
-	t_list_d *cmpnt_list, t_list_d *cmpnt_node, char *target_dir)
+		t_list_d *cmpnt_list, t_list_d *cmpnt_node, char *target_dir)
 {
 	char	*path;
 
@@ -31,7 +31,8 @@ int	check_cmpnt_node_path(
 	return (free(path), SUCCESS);
 }
 
-int	get_path_len_from_cmpnt_node(t_list_d *cmpnt_list, t_list_d *cmpnt_node)
+int	get_path_len_from_cmpnt_node(
+		t_list_d *cmpnt_list, t_list_d *cmpnt_node)
 {
 	int	len;
 

--- a/source/backend/builtins/export/export_output.c
+++ b/source/backend/builtins/export/export_output.c
@@ -14,21 +14,15 @@
 #include "utils.h"
 
 static int		get_total_export_printout_len(
-					t_list *env_list,
-					int prefix_len,
-					int format_len);
+					t_list *env_list, int prefix_len, int format_len);
 static int		get_env_str_len(
-					t_env *env_node,
-					int prefix_len,
-					int format_len);
+					t_env *env_node, int prefix_len, int format_len);
 static void		fill_export_printout(
 					t_list *env_list,
 					char *export_printout,
 					int prefix_len,
 					int format_len);
-static t_env	*get_next_env_node(
-					t_list *env_list,
-					char *prev_key);
+static t_env	*get_next_env_node(t_list *env_list, char *prev_key);
 
 /**
  * Print all exported env vars in ASCII order, with "export " prepended.
@@ -38,8 +32,7 @@ static t_env	*get_next_env_node(
  * Malloc once, then use ft_snprintf to fill.
  * Then print once.
  */
-int	print_exported_env(
-	t_list *env_list)
+int	print_exported_env(t_list *env_list)
 {
 	char	*export_printout;
 	int		format_len;
@@ -61,9 +54,7 @@ int	print_exported_env(
 }
 
 static int	get_total_export_printout_len(
-	t_list *env_list,
-	int prefix_len,
-	int format_len)
+				t_list *env_list, int prefix_len, int format_len)
 {
 	t_env	*env_node;
 	int		total_len;
@@ -80,9 +71,7 @@ static int	get_total_export_printout_len(
 }
 
 static int	get_env_str_len(
-	t_env *env_node,
-	int prefix_len,
-	int format_len)
+				t_env *env_node, int prefix_len, int format_len)
 {
 	int	len;
 
@@ -95,10 +84,10 @@ static int	get_env_str_len(
 }
 
 static void	fill_export_printout(
-		t_list *env_list,
-		char *export_printout,
-		int prefix_len,
-		int format_len)
+				t_list *env_list,
+				char *export_printout,
+				int prefix_len,
+				int format_len)
 {
 	t_env	*env_node;
 	int		i;
@@ -126,9 +115,7 @@ static void	fill_export_printout(
 	}
 }
 
-static t_env	*get_next_env_node(
-	t_list *env_list,
-	char *prev_key)
+static t_env	*get_next_env_node(t_list *env_list, char *prev_key)
 {
 	t_env	*env_node;
 	t_env	*next_node;

--- a/source/backend/executor/executor_utils.c
+++ b/source/backend/executor/executor_utils.c
@@ -14,7 +14,8 @@
 #include "signals.h"
 #include "utils.h"
 
-int	set_expanded_cmd_name(char **cmd_name, t_sh *shell, t_list *simple_cmd_list)
+int	set_expanded_cmd_name(
+		char **cmd_name, t_sh *shell, t_list *simple_cmd_list)
 {
 	t_list	*expanded_list;
 	int		ret;

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -14,18 +14,13 @@
 #include "utils.h"
 
 static t_hd_st	handle_heredoc(
-					t_sh *shell,
-					int cmdtable_id,
-					t_list *io_red_list);
+					t_sh *shell, int cmdtable_id, t_list *io_red_list);
 static t_hd_st	exec_heredoc(
 					t_sh *shell,
 					int cmdtable_id,
 					t_io_red *io_red,
 					bool need_content_expansion);
-static t_hd_st	read_heredoc(
-					t_sh *shell,
-					t_list **line_list,
-					char *here_end);
+static t_hd_st	read_heredoc(t_sh *shell, t_list **line_list, char *here_end);
 static t_hd_st	handle_heredoc_content(
 					t_sh *shell,
 					char *filename,
@@ -37,8 +32,7 @@ static t_hd_st	handle_heredoc_content(
  *     1. the here-document lines shall not undergo expansion
  *     2. the quotes shall be removed from the delimiter
  */
-t_hd_st	heredoc(
-	t_sh *shell)
+t_hd_st	heredoc(t_sh *shell)
 {
 	t_ct		*cur_cmd_table;
 	t_list_d	*cmd_table_node;
@@ -58,9 +52,7 @@ t_hd_st	heredoc(
 }
 
 static t_hd_st	handle_heredoc(
-	t_sh *shell,
-	int cmdtable_id,
-	t_list *io_red_list)
+					t_sh *shell, int cmdtable_id, t_list *io_red_list)
 {
 	t_io_red	*io_red;
 	t_hd_st		ret;
@@ -87,10 +79,10 @@ static t_hd_st	handle_heredoc(
 }
 
 static t_hd_st	exec_heredoc(
-	t_sh *shell,
-	int cmdtable_id,
-	t_io_red *io_red,
-	bool need_content_expansion)
+					t_sh *shell,
+					int cmdtable_id,
+					t_io_red *io_red,
+					bool need_content_expansion)
 {
 	t_list	*line_list;
 	t_hd_st	ret;
@@ -110,10 +102,7 @@ static t_hd_st	exec_heredoc(
 	return (HD_SUCCESS);
 }
 
-static t_hd_st	read_heredoc(
-	t_sh *shell,
-	t_list **line_list,
-	char *here_end)
+static t_hd_st	read_heredoc(t_sh *shell, t_list **line_list, char *here_end)
 {
 	char	*line;
 
@@ -138,10 +127,10 @@ static t_hd_st	read_heredoc(
 }
 
 static t_hd_st	handle_heredoc_content(
-	t_sh *shell,
-	char *filename,
-	t_list **line_list,
-	bool need_content_expansion)
+					t_sh *shell,
+					char *filename,
+					t_list **line_list,
+					bool need_content_expansion)
 {
 	char	*content;
 	t_hd_st	ret;

--- a/source/backend/redirection/heredoc_utils.c
+++ b/source/backend/redirection/heredoc_utils.c
@@ -54,7 +54,7 @@ t_hd_st	expand_heredoc_content(t_sh *shell, char **content)
 }
 
 bool	remove_here_end_quote(
-	t_sh *shell, t_io_red *io_red, bool *need_content_expansion)
+			t_sh *shell, t_io_red *io_red, bool *need_content_expansion)
 {
 	t_list	*expanded_list;
 

--- a/source/backend/redirection/io_file.c
+++ b/source/backend/redirection/io_file.c
@@ -15,23 +15,14 @@
 #include "utils.h"
 #include "clean.h"
 
-static int	expand_filename(
-				t_sh *shell,
-				char **filename);
+static int	expand_filename(t_sh *shell, char **filename);
 static bool	handle_redirect_by_type(
-				int *read_fd,
-				int *write_fd,
-				t_io_red *io_red);
-static bool	handle_red_in(
-				int *read_fd,
-				char *filename);
-static bool	handle_red_out(
-				int *write_fd,
-				char *filename,
-				int o_flags);
+				int *read_fd, int *write_fd, t_io_red *io_red);
+static bool	handle_red_in(int *read_fd, char *filename);
+static bool	handle_red_out(int *write_fd, char *filename, int o_flags);
 
 int	handle_io_redirect(
-	t_sh *shell, int *read_fd, int *write_fd, t_list *io_red_list)
+		t_sh *shell, int *read_fd, int *write_fd, t_list *io_red_list)
 {
 	t_io_red	*io_red;
 	int			ret;
@@ -54,9 +45,7 @@ int	handle_io_redirect(
 	return (SUCCESS);
 }
 
-static int	expand_filename(
-	t_sh *shell,
-	char **filename)
+static int	expand_filename(t_sh *shell, char **filename)
 {
 	t_expd_op	op_mask;
 	t_list		*expanded_list;
@@ -82,9 +71,7 @@ static int	expand_filename(
 }
 
 static bool	handle_redirect_by_type(
-	int *read_fd,
-	int *write_fd,
-	t_io_red *io_red)
+				int *read_fd, int *write_fd, t_io_red *io_red)
 {
 	if (io_red->type == T_RED_IN || io_red->type == T_HERE_DOC)
 		return (handle_red_in(read_fd, io_red->filename));
@@ -97,9 +84,7 @@ static bool	handle_redirect_by_type(
 	return (true);
 }
 
-static bool	handle_red_in(
-	int *read_fd,
-	char *filename)
+static bool	handle_red_in(int *read_fd, char *filename)
 {
 	int	fd;
 
@@ -114,10 +99,7 @@ static bool	handle_red_in(
 	return (true);
 }
 
-static bool	handle_red_out(
-	int *write_fd,
-	char *filename,
-	int o_flags)
+static bool	handle_red_out(int *write_fd, char *filename, int o_flags)
 {
 	int	fd;
 

--- a/source/debug/print_ast_bfs.c
+++ b/source/debug/print_ast_bfs.c
@@ -22,15 +22,10 @@ static t_rel_ast	*init_relation_ast_node(
 						t_ast *parent,
 						t_ast *current,
 						t_list *children);
-static int			print_relation_ast_node(
-						t_rel_ast *node,
-						int cur_level);
-static bool			append_children_to_queue(
-						t_list **queue,
-						t_rel_ast *node);
+static int			print_relation_ast_node(t_rel_ast *node, int cur_level);
+static bool			append_children_to_queue(t_list **queue, t_rel_ast *node);
 
-bool	print_ast_bfs(
-	t_ast *root)
+bool	print_ast_bfs(t_ast *root)
 {
 	t_list		*queue;
 	t_rel_ast	*node;
@@ -86,9 +81,7 @@ static t_rel_ast	*init_relation_ast_node(
 	return (node);
 }
 
-static int	print_relation_ast_node(
-	t_rel_ast *node,
-	int cur_level)
+static int	print_relation_ast_node(t_rel_ast *node, int cur_level)
 {
 	if (node->level != cur_level)
 	{
@@ -102,9 +95,7 @@ static int	print_relation_ast_node(
 	return (cur_level);
 }
 
-static bool	append_children_to_queue(
-	t_list **queue,
-	t_rel_ast *node)
+static bool	append_children_to_queue(t_list **queue, t_rel_ast *node)
 {
 	while (node->children)
 	{

--- a/source/frontend/expander/expander.c
+++ b/source/frontend/expander/expander.c
@@ -13,15 +13,13 @@
 #include "expander.h"
 
 static bool	handle_expansion(
-				t_list **expanded_list,
-				t_sh *shell,
-				t_expd_op op_mask);
+				t_list **expanded_list, t_sh *shell, t_expd_op op_mask);
 
 int	expander(
-	char *str,
-	t_list **expanded_list,
-	t_sh *shell,
-	t_expd_op op_mask)
+		char *str,
+		t_list **expanded_list,
+		t_sh *shell,
+		t_expd_op op_mask)
 {
 	char	*new_str;
 
@@ -40,9 +38,7 @@ int	expander(
 }
 
 static bool	handle_expansion(
-	t_list **expanded_list,
-	t_sh *shell,
-	t_expd_op op_mask)
+				t_list **expanded_list, t_sh *shell, t_expd_op op_mask)
 {
 	char	**base_str;
 	t_list	*task_list;

--- a/source/frontend/expander/expander_task_list.c
+++ b/source/frontend/expander/expander_task_list.c
@@ -13,24 +13,14 @@
 #include "expander.h"
 #include "utils.h"
 
-static bool	append_quote_task(
-				t_list **task_list,
-				char **base_str,
-				int *i);
+static bool	append_quote_task(t_list **task_list, char **base_str, int *i);
 static bool	append_parameter_task(
-				t_list **task_list,
-				char **base_str,
-				int *i,
-				t_expd_op op_mask);
+				t_list **task_list, char **base_str, int *i, t_expd_op op_mask);
 static bool	set_parameter_task_type(
-				t_expd_tsk_typ *type,
-				char c,
-				t_expd_op op_mask);
+				t_expd_tsk_typ *type, char c, t_expd_op op_mask);
 
 bool	set_expander_task_list(
-	t_list **task_list,
-	char **base_str,
-	t_expd_op op_mask)
+			t_list **task_list, char **base_str, t_expd_op op_mask)
 {
 	int		i;
 	bool	ret;
@@ -49,10 +39,7 @@ bool	set_expander_task_list(
 	return (is_open_pair(0, OP_CLEAN), ret);
 }
 
-static bool	append_quote_task(
-	t_list **task_list,
-	char **base_str,
-	int *i)
+static bool	append_quote_task(t_list **task_list, char **base_str, int *i)
 {
 	t_expd_tsk	*task;
 
@@ -68,10 +55,7 @@ static bool	append_quote_task(
 }
 
 static bool	append_parameter_task(
-	t_list **task_list,
-	char **base_str,
-	int *i,
-	t_expd_op op_mask)
+				t_list **task_list, char **base_str, int *i, t_expd_op op_mask)
 {
 	int				offset;
 	int				replace_len;
@@ -92,9 +76,7 @@ static bool	append_parameter_task(
 }
 
 static bool	set_parameter_task_type(
-	t_expd_tsk_typ *type,
-	char c,
-	t_expd_op op_mask)
+				t_expd_tsk_typ *type, char c, t_expd_op op_mask)
 {
 	if (is_valid_varname_start(c))
 	{

--- a/source/frontend/expander/expander_task_list_utils.c
+++ b/source/frontend/expander/expander_task_list_utils.c
@@ -26,7 +26,8 @@ bool	any_task_of_type(t_list *task_list, t_expd_tsk_typ type)
 	return (false);
 }
 
-void	drop_task_types(t_list **task_list, char **word, t_expd_tsk_typ type)
+void	drop_task_types(
+			t_list **task_list, char **word, t_expd_tsk_typ type)
 {
 	t_expd_tsk	*task;
 	t_list		*task_node;
@@ -43,7 +44,7 @@ void	drop_task_types(t_list **task_list, char **word, t_expd_tsk_typ type)
 }
 
 t_list	*get_expander_task_node(
-	t_list *task_list, char **base_str, int i, t_expd_tsk_typ type)
+			t_list *task_list, char **base_str, int i, t_expd_tsk_typ type)
 {
 	t_expd_tsk	*task;
 
@@ -58,7 +59,8 @@ t_list	*get_expander_task_node(
 	return (NULL);
 }
 
-void	update_expander_tasks(t_list *task_list, int diff, char **new_base_str)
+void	update_expander_tasks(
+			t_list *task_list, int diff, char **new_base_str)
 {
 	char		**old_base_str;
 	t_expd_tsk	*task;

--- a/source/frontend/expander/expander_task_utils.c
+++ b/source/frontend/expander/expander_task_utils.c
@@ -13,7 +13,7 @@
 #include "utils.h"
 
 t_expd_tsk	*init_expander_task(
-	t_expd_tsk_typ type, int start, int replace_len, char *str)
+				t_expd_tsk_typ type, int start, int replace_len, char *str)
 {
 	t_expd_tsk	*task;
 

--- a/source/frontend/expander/wildcard_expansion.c
+++ b/source/frontend/expander/wildcard_expansion.c
@@ -13,13 +13,8 @@
 #include "expander.h"
 
 static bool	iter_word_list(
-				t_list **expanded_list,
-				t_list *file_list,
-				t_list **task_list);
-static bool	match_filename(
-				char *filename,
-				char *word,
-				t_list *task_list);
+				t_list **expanded_list, t_list *file_list, t_list **task_list);
+static bool	match_filename(char *filename, char *word, t_list *task_list);
 static bool	expand_wildcard(
 				t_list **tmp_lst,
 				char *word,
@@ -27,8 +22,7 @@ static bool	expand_wildcard(
 				t_list *task_list);
 
 bool	handle_wildcard_expansion(
-	t_list **expanded_list,
-	t_list **task_list)
+			t_list **expanded_list, t_list **task_list)
 {
 	t_list	*file_list;
 
@@ -45,9 +39,7 @@ bool	handle_wildcard_expansion(
 }
 
 static bool	iter_word_list(
-	t_list **expanded_list,
-	t_list *file_list,
-	t_list **task_list)
+				t_list **expanded_list, t_list *file_list, t_list **task_list)
 {
 	t_list	*cur;
 	t_list	*tmp_lst;
@@ -75,10 +67,7 @@ static bool	iter_word_list(
 	return (true);
 }
 
-static bool	match_filename(
-	char *filename,
-	char *word,
-	t_list *task_list)
+static bool	match_filename(char *filename, char *word, t_list *task_list)
 {
 	if (*filename == '.')
 	{
@@ -107,10 +96,10 @@ static bool	match_filename(
 }
 
 static bool	expand_wildcard(
-	t_list **tmp_lst,
-	char *word,
-	t_list *file_list,
-	t_list *task_list)
+				t_list **tmp_lst,
+				char *word,
+				t_list *file_list,
+				t_list *task_list)
 {
 	char	*dup;
 

--- a/source/frontend/expander/wildcard_task_list.c
+++ b/source/frontend/expander/wildcard_task_list.c
@@ -17,15 +17,10 @@ static bool	iter_base_str(
 				t_list **new_task_list,
 				t_list **old_task_list,
 				char **base_str);
-static bool	append_wildcard_task(
-				t_list **task_list,
-				char **base_str,
-				int *i);
+static bool	append_wildcard_task(t_list **task_list, char **base_str, int *i);
 
 bool	set_wildcard_task_list(
-	t_list **task_list,
-	t_list *expanded_list,
-	t_expd_op op_mask)
+			t_list **task_list, t_list *expanded_list, t_expd_op op_mask)
 {
 	char	**base_str;
 	t_list	*new_task_list;
@@ -46,9 +41,9 @@ bool	set_wildcard_task_list(
 }
 
 static bool	iter_base_str(
-	t_list **new_task_list,
-	t_list **old_task_list,
-	char **base_str)
+				t_list **new_task_list,
+				t_list **old_task_list,
+				char **base_str)
 {
 	int		i;
 	bool	ret;
@@ -74,10 +69,7 @@ static bool	iter_base_str(
 	return (ret);
 }
 
-static bool	append_wildcard_task(
-	t_list **task_list,
-	char **base_str,
-	int *i)
+static bool	append_wildcard_task(t_list **task_list, char **base_str, int *i)
 {
 	int			replace_len;
 	t_expd_tsk	*task;

--- a/source/frontend/expander/word_splitting.c
+++ b/source/frontend/expander/word_splitting.c
@@ -12,22 +12,13 @@
 
 #include "expander.h"
 
-static bool	iter_word_splitting(
-				t_list *expanded_list,
-				t_list **task_list);
-static bool	split_str_into_nodes(
-				t_list **expanded_list,
-				t_list *task_node);
+static bool	iter_word_splitting(t_list *expanded_list, t_list **task_list);
+static bool	split_str_into_nodes(t_list **expanded_list, t_list *task_node);
 static bool	split_node(
-				t_list **expanded_list,
-				t_list *task_node,
-				int *i,
-				int *end);
+				t_list **expanded_list, t_list *task_node, int *i, int *end);
 
 bool	handle_word_splitting(
-	t_list **expanded_list,
-	t_expd_op op_mask,
-	t_list **task_list)
+			t_list **expanded_list, t_expd_op op_mask, t_list **task_list)
 {
 	if (op_mask & E_SPLIT_WORDS)
 	{
@@ -38,9 +29,7 @@ bool	handle_word_splitting(
 	return (true);
 }
 
-static bool	iter_word_splitting(
-	t_list *expanded_list,
-	t_list **task_list)
+static bool	iter_word_splitting(t_list *expanded_list, t_list **task_list)
 {
 	t_expd_tsk	*task;
 	t_list		*task_node;
@@ -61,9 +50,7 @@ static bool	iter_word_splitting(
 	return (true);
 }
 
-static bool	split_str_into_nodes(
-	t_list **expanded_list,
-	t_list *task_node)
+static bool	split_str_into_nodes(t_list **expanded_list, t_list *task_node)
 {
 	char		**base_str;
 	int			end;
@@ -90,10 +77,7 @@ static bool	split_str_into_nodes(
 }
 
 static bool	split_node(
-	t_list **expanded_list,
-	t_list *task_node,
-	int *i,
-	int *end)
+				t_list **expanded_list, t_list *task_node, int *i, int *end)
 {
 	char	**base_str;
 	char	*rest;

--- a/source/frontend/expander/word_splitting_utils.c
+++ b/source/frontend/expander/word_splitting_utils.c
@@ -44,7 +44,10 @@ int	trim_front_whitespace(char **base_str, int *i, int *end)
 }
 
 bool	append_rest_to_list(
-	t_list **expanded_list, t_list *task_node, char *rest, int trimmed_len)
+			t_list **expanded_list,
+			t_list *task_node,
+			char *rest,
+			int trimmed_len)
 {
 	char		**new_base_str;
 	t_list		*new_node;

--- a/source/frontend/lexer/token_list.c
+++ b/source/frontend/lexer/token_list.c
@@ -13,17 +13,11 @@
 #include "lexer.h"
 #include "utils.h"
 
-static bool	separate_operators(
-				t_list *token_node,
-				int i);
+static bool	separate_operators(t_list *token_node, int i);
 static bool	split_and_advance_node(
-				t_list **token_node,
-				char **token_data,
-				int *i);
+				t_list **token_node, char **token_data, int *i);
 
-bool	create_token_list(
-	t_list **token_list,
-	t_list **token_data_list)
+bool	create_token_list(t_list **token_list, t_list **token_data_list)
 {
 	t_list	*new_nodes;
 	t_tok	*token;
@@ -51,8 +45,7 @@ bool	create_token_list(
 	return (true);
 }
 
-bool	append_end_node(
-	t_list	**token_list)
+bool	append_end_node(t_list	**token_list)
 {
 	t_tok	*token;
 
@@ -62,9 +55,7 @@ bool	append_end_node(
 	return (true);
 }
 
-static bool	separate_operators(
-	t_list *token_node,
-	int i)
+static bool	separate_operators(t_list *token_node, int i)
 {
 	char	*token_data;
 
@@ -89,9 +80,7 @@ static bool	separate_operators(
 }
 
 static bool	split_and_advance_node(
-	t_list **token_node,
-	char **token_data,
-	int *i)
+				t_list **token_node, char **token_data, int *i)
 {
 	if (*i == 0)
 		skip_operator(*token_data, i);

--- a/source/frontend/parser/cmd_table_list.c
+++ b/source/frontend/parser/cmd_table_list.c
@@ -14,13 +14,10 @@
 #include "utils.h"
 
 static bool	handle_current_token(
-				t_list **token_list,
-				t_list_d **cmd_table_list);
-static void	fill_subshell_level(
-				t_list_d *cmd_table_list);
+				t_list **token_list, t_list_d **cmd_table_list);
+static void	fill_subshell_level(t_list_d *cmd_table_list);
 
-t_list_d	*build_cmd_table_list(
-	t_list *token_list)
+t_list_d	*build_cmd_table_list(t_list *token_list)
 {
 	t_list_d	*cmd_table_list;
 
@@ -37,8 +34,7 @@ t_list_d	*build_cmd_table_list(
 }
 
 static bool	handle_current_token(
-	t_list **token_list,
-	t_list_d **cmd_table_list)
+				t_list **token_list, t_list_d **cmd_table_list)
 {
 	t_tok_typ	token_type;
 
@@ -61,8 +57,7 @@ static bool	handle_current_token(
 	return (false);
 }
 
-static void	fill_subshell_level(
-	t_list_d *cmd_table_list)
+static void	fill_subshell_level(t_list_d *cmd_table_list)
 {
 	t_ct	*cmd_table;
 	int		level;

--- a/source/frontend/parser/parser_action.c
+++ b/source/frontend/parser/parser_action.c
@@ -16,7 +16,10 @@
 static bool	push_node(t_list **parse_stack, t_ast *ast_node);
 
 bool	parse_shift(
-	t_tok *token, t_list **state_stack, t_list **parse_stack, int next_state)
+			t_tok *token,
+			t_list **state_stack,
+			t_list **parse_stack,
+			int next_state)
 {
 	t_ast	*ast_node;
 
@@ -32,7 +35,9 @@ bool	parse_shift(
 }
 
 bool	parse_reduce(
-	t_list **state_stack, t_list **parse_stack, t_pt_node *pt_entry)
+			t_list **state_stack,
+			t_list **parse_stack,
+			t_pt_node *pt_entry)
 {
 	t_list	*children;
 	t_ast	*reduce_node;

--- a/source/frontend/parser/parsing_table_operation.c
+++ b/source/frontend/parser/parsing_table_operation.c
@@ -18,14 +18,13 @@ static bool			match_rule(
 						t_prs_act action_mask,
 						int row_index,
 						const int parsing_table[PT_ROW_NUM][PT_COL_NUM]);
-static t_pt_node	*init_pt_node(
-						const int pt_row[PT_ROW_NUM]);
+static t_pt_node	*init_pt_node(const int pt_row[PT_ROW_NUM]);
 
 bool	set_next_pt_entry(
-	t_pt_node **pt_entry,
-	int state,
-	t_prs_elem element,
-	t_prs_act action_mask)
+			t_pt_node **pt_entry,
+			int state,
+			t_prs_elem element,
+			t_prs_act action_mask)
 {
 	const int	parsing_table[PT_ROW_NUM][PT_COL_NUM] = PARSING_TABLE;
 	int			i;
@@ -49,10 +48,10 @@ bool	set_next_pt_entry(
 }
 
 static bool	match_rule(
-	t_prs_elem element,
-	t_prs_act action_mask,
-	int row_index,
-	const int parsing_table[PT_ROW_NUM][PT_COL_NUM])
+				t_prs_elem element,
+				t_prs_act action_mask,
+				int row_index,
+				const int parsing_table[PT_ROW_NUM][PT_COL_NUM])
 {
 	if ((action_mask & A_ACCEPT) == A_ACCEPT && \
 		parsing_table[row_index][PT_COL_ACTION] == A_ACCEPT)
@@ -71,8 +70,7 @@ static bool	match_rule(
 	return (false);
 }
 
-static t_pt_node	*init_pt_node(
-	const int pt_row[PT_ROW_NUM])
+static t_pt_node	*init_pt_node(const int pt_row[PT_ROW_NUM])
 {
 	t_pt_node	*pt_node;
 

--- a/source/utils/cmd_table_list_utils.c
+++ b/source/utils/cmd_table_list_utils.c
@@ -14,7 +14,8 @@
 
 static bool	append_empty_cmd_table(t_list_d **cmd_table_list);
 
-bool	append_cmd_table_by_scenario(t_tok_typ token_type, t_list_d **cmd_table_list)
+bool	append_cmd_table_by_scenario(
+			t_tok_typ token_type, t_list_d **cmd_table_list)
 {
 	if (*cmd_table_list)
 	{

--- a/source/utils/env_list_operation_utils.c
+++ b/source/utils/env_list_operation_utils.c
@@ -14,7 +14,7 @@
 #include "clean.h"
 
 bool	append_env_node(
-	t_list **env_list, char *key, char *value, t_expt export)
+			t_list **env_list, char *key, char *value, t_expt export)
 {
 	t_env	*env_node;
 
@@ -38,7 +38,8 @@ void	free_env_node(t_env *env)
 	free(env);
 }
 
-bool	process_str_to_env_list(char *str, t_list **env_list, t_expt export)
+bool	process_str_to_env_list(
+			char *str, t_list **env_list, t_expt export)
 {
 	char	*key;
 	char	*value;
@@ -69,7 +70,7 @@ void	remove_env_node(t_list **env_list, char *key, char *value)
 }
 
 bool	replace_env_value(
-	t_list *env_list, char *key, char *value, char **old_value)
+			t_list *env_list, char *key, char *value, char **old_value)
 {
 	t_env	*env_node;
 

--- a/source/utils/expansion_utils.c
+++ b/source/utils/expansion_utils.c
@@ -14,7 +14,10 @@
 #include "utils.h"
 
 int	expand_list(
-	t_sh *shell, t_list *list, t_list **expanded_list, t_expd_op op_mask)
+		t_sh *shell,
+		t_list *list,
+		t_list **expanded_list,
+		t_expd_op op_mask)
 {
 	int		ret;
 	t_list	*tmp_list;

--- a/source/utils/final_cmd_table_setup.c
+++ b/source/utils/final_cmd_table_setup.c
@@ -71,7 +71,8 @@ bool	setup_exec_path(t_sh *shell, t_fct *final_cmd_table)
 	return (true);
 }
 
-bool	setup_assignment_array(t_fct *final_cmd_table, t_list *assignment_list)
+bool	setup_assignment_array(
+			t_fct *final_cmd_table, t_list *assignment_list)
 {
 	final_cmd_table->assignment_array = NULL;
 	if (!assignment_list)

--- a/source/utils/user_input_utils.c
+++ b/source/utils/user_input_utils.c
@@ -13,7 +13,10 @@
 #include "defines.h"
 
 bool	read_input(
-	char **line, char *prompt, bool add_to_history, bool is_interactive)
+			char **line,
+			char *prompt,
+			bool add_to_history,
+			bool is_interactive)
 {
 	char	*tmp;
 


### PR DESCRIPTION
### Applied rules:
1. If possible, put all parameters into same line as function name.
2. Else, if possible, put all parameters one line below the function name and indent one tab after the function name.
3. Else, separate each parameter into its own line below the function name, all indentend one tab after the function name.

The function signature should be the same across the definition and prototype at the top of .c files or in .h files.

---

Let me know if you like it.
I tried to mostly keep your style, with two slight adjustments for readability and consistency:
- If the parameters don't fit all into the same line as the function name, skip the step of leaving one parameter in the function name line and put all parameters into the next line immediately.
- Keep all signatures consistent across source and header files. If in the header file a function requires a different indentation, also change it in the .c file.