### PR TITLE
[LIB] Use bitwise operators in basic alphabet functions to improve performance

### DIFF
--- a/libraries/libft/src/libft/chars/ft_isalpha.c
+++ b/libraries/libft/src/libft/chars/ft_isalpha.c
@@ -12,7 +12,8 @@
 
 int	ft_isalpha(int c)
 {
-	if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
+	c |= 32;
+	if (c >= 'a' && c <= 'z')
 		return (1);
 	else
 		return (0);

--- a/libraries/libft/src/libft/chars/ft_tolower.c
+++ b/libraries/libft/src/libft/chars/ft_tolower.c
@@ -12,8 +12,5 @@
 
 int	ft_tolower(int c)
 {
-	if (c >= 'A' && c <= 'Z')
-		return (c + 32);
-	else
-		return (c);
+	return (c | 32);
 }

--- a/libraries/libft/src/libft/chars/ft_toupper.c
+++ b/libraries/libft/src/libft/chars/ft_toupper.c
@@ -12,8 +12,5 @@
 
 int	ft_toupper(int c)
 {
-	if (c >= 'a' && c <= 'z')
-		return (c - 32);
-	else
-		return (c);
+	return (c & ~32);
 }


### PR DESCRIPTION
It might have an impact for wildcard expansion inside of a directory with a huge amount of files.
In wildcard expansion, `ft_isalpha()`, `ft_tolower()` and `ft_toupper()` are used a lot in merge sort.