### PR TITLE
[REVERT] Revert PR #323

### DIFF
--- a/libraries/libft/src/libft/chars/ft_isalpha.c
+++ b/libraries/libft/src/libft/chars/ft_isalpha.c
@@ -12,8 +12,7 @@
 
 int	ft_isalpha(int c)
 {
-	c |= 32;
-	if (c >= 'a' && c <= 'z')
+	if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
 		return (1);
 	else
 		return (0);

--- a/libraries/libft/src/libft/chars/ft_tolower.c
+++ b/libraries/libft/src/libft/chars/ft_tolower.c
@@ -12,5 +12,8 @@
 
 int	ft_tolower(int c)
 {
-	return (c | 32);
+	if (c >= 'A' && c <= 'Z')
+		return (c + 32);
+	else
+		return (c);
 }

--- a/libraries/libft/src/libft/chars/ft_toupper.c
+++ b/libraries/libft/src/libft/chars/ft_toupper.c
@@ -12,5 +12,8 @@
 
 int	ft_toupper(int c)
 {
-	return (c & ~32);
+	if (c >= 'a' && c <= 'z')
+		return (c - 32);
+	else
+		return (c);
 }


### PR DESCRIPTION
The bitwise operations messed up non-alphabetic characters.
To fix this, adding a `ft_isalpha()` check in front defeats the performance reason to use bitwise operators.