### PR TITLE
[BUILD] Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ LIB_DIR			:=	libraries
 
 #	Dependencies
 
-LIBRARIES		:=	$(wildcard $(LIB_DIR)/*)
+LIBRARIES		:=	$(LIB_DIR)/libft
 LIBRARIES_EXT	:=	readline termcap
 INCLUDES 		:=	-I./include -I./$(LIBRARIES)/inc
 BUILDFILES		:=	Makefile \

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ endif
 
 #	Library compilation
 
-export				MAKECMDGOALS
+export				CC CFLAGS MAKECMDGOALS MAKEFLAGS
 
 lib				:
 					$(MAKE) -C $(LIBRARIES)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ BUILDFILES		:=	Makefile \
 
 CC 				:=	cc
 CC_VERSION		:=	$(shell $(CC) --version | head -1)
-CFLAGS 			:=	-Wall -Wextra -Werror -g
+CFLAGS 			:=	-Wall -Wextra -Werror -ggdb3
 INCFLAGS 		:=	$(addprefix -I,$(INC_DIR) $(LIB_INCLUDES))
 LIBFLAGS		:=	$(addprefix -L,$(LIBRARIES)) \
 					$(addprefix -l,$(patsubst lib%,%,$(notdir \

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ NAME 			:=	minishell
 #	Directories
 
 SRC_DIR			:=	source
+INC_DIR			:=	include
 BUILD_DIR		:=	build
 OBJ_DIR			:=	$(BUILD_DIR)/_obj
 DEP_DIR			:=	$(BUILD_DIR)/_dep
@@ -31,7 +32,7 @@ LIB_DIR			:=	libraries
 
 LIBRARIES		:=	$(LIB_DIR)/libft
 LIBRARIES_EXT	:=	readline termcap
-INCLUDES 		:=	-I./include -I./$(LIBRARIES)/inc
+LIB_INCLUDES 	:=	$(LIB_DIR)/libft/inc
 BUILDFILES		:=	Makefile \
 					$(BUILD_DIR)/parsing_table.mk \
 					$(BUILD_DIR)/source_files.mk \
@@ -43,6 +44,7 @@ BUILDFILES		:=	Makefile \
 CC 				:=	cc
 CC_VERSION		:=	$(shell $(CC) --version | head -1)
 CFLAGS 			:=	-Wall -Wextra -Werror -g
+INCFLAGS 		:=	$(addprefix -I,$(INC_DIR) $(LIB_INCLUDES))
 LIBFLAGS		:=	$(addprefix -L,$(LIBRARIES)) \
 					$(addprefix -l,$(patsubst lib%,%,$(notdir \
 					$(LIBRARIES) $(LIBRARIES_EXT))))
@@ -173,20 +175,20 @@ waitforlib		:	lib
 #	Executable linking
 
 $(NAME)			:	$(LIBRARIES) $(OBJ)
-					$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) $(LIBFLAGS) -o $(NAME)
+					$(CC) $(CFLAGS) $(INCFLAGS) $(OBJ) $(LIBFLAGS) -o $(NAME)
 
 
 #	Source file compiling
 
 $(OBJ_DIR)/%.o	:	%.c $(BUILDFILES) | $(OBJ_SUBDIRS)
-					$(CC) $(CFLAGS) $(MACROS) $(INCLUDES) -c $< -o $@ \
+					$(CC) $(CFLAGS) $(MACROS) $(INCFLAGS) -c $< -o $@ \
 						&& echo -n $(MSG_PROGRESS)
 
 
 #	Pre-processing and dependency file creation
 
 $(DEP_DIR)/%.d	:	%.c $(BUILDFILES) | $(DEP_SUBDIRS)
-					$(CC) $(CFLAGS) $(MACROS) $(INCLUDES) \
+					$(CC) $(CFLAGS) $(MACROS) $(INCFLAGS) \
 						-M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@" $<
 
 

--- a/libraries/libft/Makefile
+++ b/libraries/libft/Makefile
@@ -34,7 +34,7 @@ SOURCELISTS		:=	libft.mk \
 
 # Flags:
 CC				?=	cc
-CFLAGS			?=	-Wall -Wextra -Werror -g
+CFLAGS			?=	-Wall -Wextra -Werror
 INCFLAGS		:=	$(addprefix -I,$I)
 DEBUGFLAGS		:=	-g
 ARFLAGS			:=	rcs

--- a/libraries/libft/Makefile
+++ b/libraries/libft/Makefile
@@ -34,7 +34,8 @@ SOURCELISTS		:=	libft.mk \
 
 # Flags:
 CC				?=	cc
-CFLAGS			?=	-Wall -Wextra -Werror $(addprefix -I,$I) -g
+CFLAGS			?=	-Wall -Wextra -Werror -g
+INCFLAGS		:=	$(addprefix -I,$I)
 DEBUGFLAGS		:=	-g
 ARFLAGS			:=	rcs
 
@@ -60,10 +61,10 @@ $(NAME)			:	$(OBJ)
 					ar $(ARFLAGS) $(NAME) $(OBJ)
 
 $(OBJ):	$O%.o	:	$S%.c | $(SUBDIRS_O)
-					$(CC) $(CFLAGS) -c $< -o $@
+					$(CC) $(CFLAGS) $(INCFLAGS) -c $< -o $@
 
 $(DEP):	$D%.d	:	$S%.c | $(SUBDIRS_D)
-	@				$(CC) $(CFLAGS) -M -MP -MF $@ -MT "$O$*.o $@" $<
+	@				$(CC) $(CFLAGS) $(INCFLAGS) -M -MP -MF $@ -MT "$O$*.o $@" $<
 
 $(SUBDIRS_O) $(SUBDIRS_D):
 	@				mkdir -p $@


### PR DESCRIPTION
The libft Makefile will now inherit many of the Makefile variables from the minishell Makefile.
This makes libft compile in the exact same way as minishell does.

For example, if you'd like to compile with -O3 or without -g, it will also apply to libft.