### PR TITLE
[FIX] Fix interleaved error messages

### DIFF
--- a/build/source_files.mk
+++ b/build/source_files.mk
@@ -164,6 +164,7 @@ SRC		+=	$(addprefix $(DIR), \
             env_list_operation_utils.c \
             env_list_status_utils.c \
             env_utils.c \
+            error_utils.c \
             exec_path_setup_utils.c \
             expansion_utils.c \
             file_utils.c \

--- a/include/defines.h
+++ b/include/defines.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 15:56:26 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/08 17:25:12 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/05 12:37:49 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -121,6 +121,7 @@
 # define EXPORT_PREFIX		"export "
 
 /* Error Messages */
+# define ERROR_MAX_LEN 131072
 # define ERROR_LEXER_SYNTAX					\
 "%s: syntax error: missing `%c'\n"
 # define ERROR_PARSER_SYNTAX				\

--- a/include/defines.h
+++ b/include/defines.h
@@ -286,7 +286,7 @@ typedef enum e_exit_argument_error
 	EX_NO_ARGS		= -1,
 	EX_NORM_ARGS	= 0,
 	EX_TOO_MANY_ARGS,
-	EX_NOT_NUMERIC,
+	EX_NOT_NUMERIC
 }	t_exit_err;
 
 typedef struct s_environment_node

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/17 13:38:17 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/08 18:03:51 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/03 17:16:26 by lyeh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,5 +134,8 @@ void		clear_terminal_soft(void);
 
 /* Pid utils */
 pid_t	getpid_from_proc(void);
+
+/* Error utils */
+void		print_error(char *fmt, ...);
 
 #endif

--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/16 13:33:38 by ldulling          #+#    #+#              #
-#    Updated: 2024/03/31 23:45:20 by ldulling         ###   ########.fr        #
+#    Updated: 2024/05/05 17:21:36 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -41,10 +41,12 @@ SRC		+=	$(addprefix $(DIR), \
 			set_format.c \
 )
 
-#  ft_snprintf:
+#  ft_snprintf + ft_vsnprintf:
 DIR		:=	ft_printf/ft_snprintf/
 SRC		+=	$(addprefix $(DIR), \
+			check_args.c \
 			ft_snprintf.c \
+			ft_vsnprintf.c \
 			get_max_size.c \
 			parseandsprint.c \
 			sprint_char.c \

--- a/libraries/libft/inc/ft_printf.h
+++ b/libraries/libft/inc/ft_printf.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/22 19:26:08 by ldulling          #+#    #+#             */
-/*   Updated: 2024/03/19 16:03:45 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/05 17:21:20 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,9 +69,10 @@ void	reset_format(t_format *f);
 int		set_format(const char *format, int *i, t_format *f, va_list *ap);
 
 \
-/* ft_snprintf */
+/* ft_snprintf + ft_vsnprintf */
 
 int		ft_snprintf(char *str, size_t size, const char *format, ...);
+int		ft_vsnprintf(char *str, size_t size, const char *format, va_list ap);
 bool	check_args(char *str, size_t size, const char *format, t_sformat *f);
 void	parseandsprint(const char *format, int *i, t_sformat *f, va_list *ap);
 void	sprint_argument(t_sformat *f, va_list *ap);

--- a/libraries/libft/src/ft_printf/ft_snprintf/check_args.c
+++ b/libraries/libft/src/ft_printf/ft_snprintf/check_args.c
@@ -1,0 +1,30 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   check_args.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/05 11:45:40 by ldulling          #+#    #+#             */
+/*   Updated: 2024/05/05 17:21:32 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_printf.h"
+
+bool	check_args(char *str, size_t size, const char *format, t_sformat *f)
+{
+	if (format == NULL)
+	{
+		if (size > 0)
+			str[0] = '\0';
+		f->sprinted = -1;
+		return (false);
+	}
+	if (size == 0)
+	{
+		f->sprinted = 0;
+		return (false);
+	}
+	return (true);
+}

--- a/libraries/libft/src/ft_printf/ft_snprintf/ft_vsnprintf.c
+++ b/libraries/libft/src/ft_printf/ft_snprintf/ft_vsnprintf.c
@@ -1,39 +1,39 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_snprintf.c                                      :+:      :+:    :+:   */
+/*   ft_vsnprintf.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/22 19:26:03 by ldulling          #+#    #+#             */
-/*   Updated: 2024/05/05 17:21:31 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/05 17:21:29 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "ft_printf.h"
 
-int	ft_snprintf(char *str, size_t size, const char *format, ...)
+int	ft_vsnprintf(char *str, size_t size, const char *format, va_list ap)
 {
 	int			i;
 	t_sformat	f;
-	va_list		ap;
+	va_list		ap_copy;
 
 	if (!check_args(str, size, format, &f))
 		return (f.sprinted);
 	f.str = str;
 	f.size = size - 1;
-	va_start(ap, format);
+	va_copy(ap_copy, ap);
 	f.unresolved = 0;
 	f.sprinted = 0;
 	i = 0;
 	while (format[i] && f.sprinted < (int) f.size)
 	{
 		reset_sformat(&f);
-		parseandsprint(format, &i, &f, &ap);
+		parseandsprint(format, &i, &f, &ap_copy);
 		if (f.sprinted == -1)
 			break ;
 	}
 	if (f.sprinted != -1)
 		f.str[f.sprinted] = '\0';
-	return (va_end(ap), f.sprinted);
+	return (va_end(ap_copy), f.sprinted);
 }

--- a/source/backend/builtins/cd/cd_errors.c
+++ b/source/backend/builtins/cd/cd_errors.c
@@ -10,17 +10,17 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "cd.h"
+#include "utils.h"
 
 int	handle_cd_error(int error, char *target_dir)
 {
 	if (error == ENOMEM || error == EIO)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: cd: ", PROGRAM_NAME);
+		print_error("%s: cd: ", PROGRAM_NAME);
 		perror(NULL);
 		return (BUILTIN_ERROR);
 	}
-	ft_dprintf(STDERR_FILENO, "%s: cd: %s: ", PROGRAM_NAME, target_dir);
+	print_error("%s: cd: %s: ", PROGRAM_NAME, target_dir);
 	perror(NULL);
 	return (GENERAL_ERROR);
 }

--- a/source/backend/builtins/cd/cd_utils.c
+++ b/source/backend/builtins/cd/cd_utils.c
@@ -17,7 +17,7 @@ bool	check_dir(char *dir, char *target_dir)
 {
 	if (is_dir(dir))
 		return (true);
-	ft_dprintf(STDERR_FILENO, "%s: cd: %s: ", PROGRAM_NAME, target_dir);
+	print_error("%s: cd: %s: ", PROGRAM_NAME, target_dir);
 	perror(NULL);
 	return (false);
 }
@@ -38,21 +38,18 @@ char	*get_target_dir(char *args[], t_list *env_list)
 	char	*target_dir;
 
 	if (get_array_len(args) > 2)
-		return (ft_dprintf(STDERR_FILENO,
-				ERROR_CD_TOO_MANY_ARGS, PROGRAM_NAME), NULL);
+		return (print_error(ERROR_CD_TOO_MANY_ARGS, PROGRAM_NAME), NULL);
 	if (!args[1])
 	{
 		target_dir = get_value_from_env_list(env_list, "HOME");
 		if (!target_dir)
-			return (ft_dprintf(STDERR_FILENO,
-					ERROR_CD_HOME_NOT_SET, PROGRAM_NAME), NULL);
+			return (print_error(ERROR_CD_HOME_NOT_SET, PROGRAM_NAME), NULL);
 	}
 	else if (ft_strcmp(args[1], "-") == 0)
 	{
 		target_dir = get_value_from_env_list(env_list, "OLDPWD");
 		if (!target_dir)
-			return (ft_dprintf(STDERR_FILENO,
-					ERROR_CD_OLDPWD_NOT_SET, PROGRAM_NAME), NULL);
+			return (print_error(ERROR_CD_OLDPWD_NOT_SET, PROGRAM_NAME), NULL);
 	}
 	else
 		target_dir = args[1];

--- a/source/backend/builtins/exit/exit.c
+++ b/source/backend/builtins/exit/exit.c
@@ -12,6 +12,7 @@
 
 #include "builtins.h"
 #include "clean.h"
+#include "utils.h"
 
 static void	handle_exit(t_sh *shell, t_exit_err args_error);
 
@@ -30,16 +31,15 @@ void	exec_exit(t_sh *shell, char *args[])
 static void	handle_exit(t_sh *shell, t_exit_err args_error)
 {
 	if (shell->subshell_level == 0 && shell->is_interactive)
-		ft_dprintf(STDERR_FILENO, EXIT_MSG);
+		print_error(EXIT_MSG);
 	if (args_error == EX_TOO_MANY_ARGS)
 	{
-		ft_dprintf(STDERR_FILENO, ERROR_EXIT_TOO_MANY_ARGS,
-			PROGRAM_NAME, "exit");
+		print_error(ERROR_EXIT_TOO_MANY_ARGS, PROGRAM_NAME, "exit");
 		if (shell->subshell_level == 0)
 			return ;
 	}
 	else if (args_error == EX_NOT_NUMERIC)
-		ft_dprintf(STDERR_FILENO, ERROR_EXIT_NUMERIC_ARG,
+		print_error(ERROR_EXIT_NUMERIC_ARG,
 			PROGRAM_NAME, "exit", shell->final_cmd_table->simple_cmd[1]);
 	clean_and_exit_shell(shell, shell->exit_code, NULL);
 }

--- a/source/backend/builtins/export/export.c
+++ b/source/backend/builtins/export/export.c
@@ -29,8 +29,7 @@ int	exec_export(char *args[], t_list **env_list)
 	{
 		if (!is_valid_varname(args[i]))
 		{
-			ft_dprintf(STDERR_FILENO, ERROR_EXPORT_INVALID_IDENTIFIER,
-				PROGRAM_NAME, args[i]);
+			print_error(ERROR_EXPORT_INVALID_IDENTIFIER, PROGRAM_NAME, args[i]);
 			ret = GENERAL_ERROR;
 		}
 		else if (!handle_var_export(args[i], env_list))

--- a/source/backend/builtins/pwd.c
+++ b/source/backend/builtins/pwd.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "defines.h"
+#include "utils.h"
 
 int	exec_pwd(void)
 {
@@ -19,7 +19,7 @@ int	exec_pwd(void)
 	pwd = getcwd(NULL, 0);
 	if (!pwd)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: %s: ", PROGRAM_NAME, "pwd");
+		print_error("%s: %s: ", PROGRAM_NAME, "pwd");
 		perror(NULL);
 		return (CMD_EXEC_FAILED);
 	}

--- a/source/backend/executor/external_cmd.c
+++ b/source/backend/executor/external_cmd.c
@@ -6,7 +6,7 @@
 /*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 15:17:06 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:44:08 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/05/03 17:18:03 by lyeh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,9 +49,9 @@ void	handle_external_cmd(t_sh *shell, t_ct *cmd_table)
 static bool	check_execfile_exist(char *exec_path, char *cmd_name)
 {
 	if (!exec_path)
-		ft_dprintf(STDERR_FILENO, ERROR_CMD_NOT_FOUND, PROGRAM_NAME, cmd_name);
+		print_error(ERROR_CMD_NOT_FOUND, PROGRAM_NAME, cmd_name);
 	else if (access(exec_path, F_OK) != 0 && errno != ENOTDIR)
-		ft_dprintf(STDERR_FILENO, "%s: %s: %s\n",
+		print_error("%s: %s: %s\n",
 			PROGRAM_NAME, exec_path, strerror(errno));
 	else
 		return (true);
@@ -72,13 +72,13 @@ static void	handle_exec_error(t_sh *shell, char *exec_path)
 
 	error = errno;
 	if (error == ENOEXEC)
-		ft_dprintf(STDERR_FILENO, ERROR_CANNOT_EXEC_FILE,
+		print_error(ERROR_CANNOT_EXEC_FILE,
 			PROGRAM_NAME, exec_path, strerror(ENOEXEC));
 	else if (is_dir(exec_path))
-		ft_dprintf(STDERR_FILENO, "%s: %s: %s\n",
+		print_error("%s: %s: %s\n",
 			PROGRAM_NAME, exec_path, strerror(EISDIR));
 	else
-		ft_dprintf(STDERR_FILENO, "%s: %s: %s\n",
+		print_error("%s: %s: %s\n",
 			PROGRAM_NAME, exec_path, strerror(error));
 	clean_and_exit_shell(shell, CMD_EXEC_FAILED, NULL);
 }

--- a/source/backend/executor/wait_process.c
+++ b/source/backend/executor/wait_process.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "clean.h"
+#include "utils.h"
 
 static int	handle_exit_status(int wstatus);
 static void	print_exit_msg(int wstatus, int signo);
@@ -69,10 +70,10 @@ static int	handle_exit_status(int wstatus)
 static void	print_exit_msg(int wstatus, int signo)
 {
 	if (signo == SIGQUIT)
-		ft_dprintf(STDERR_FILENO, "Quit");
+		print_error("Quit");
 	else if (signo == SIGSEGV)
-		ft_dprintf(STDERR_FILENO, "Segmentation fault");
+		print_error("Segmentation fault");
 	if (WCOREDUMP(wstatus))
-		ft_dprintf(STDERR_FILENO, " (core dumped)");
-	ft_dprintf(STDERR_FILENO, "\n");
+		print_error(" (core dumped)");
+	print_error("\n");
 }

--- a/source/backend/executor/wait_process.c
+++ b/source/backend/executor/wait_process.c
@@ -14,7 +14,7 @@
 #include "utils.h"
 
 static int	handle_exit_status(int wstatus);
-static void	print_exit_msg(int wstatus, int signo);
+static void	print_signaled_exit_msg(int wstatus, int signo);
 
 bool	wait_process(t_sh *shell, pid_t pid)
 {
@@ -61,19 +61,24 @@ static int	handle_exit_status(int wstatus)
 	{
 		signo = WTERMSIG(wstatus);
 		if (signo == SIGQUIT || signo == SIGSEGV)
-			print_exit_msg(wstatus, signo);
+			print_signaled_exit_msg(wstatus, signo);
 		return (TERM_BY_SIGNAL + signo);
 	}
 	return (UNEXPECT_EXIT);
 }
 
-static void	print_exit_msg(int wstatus, int signo)
+static void	print_signaled_exit_msg(int wstatus, int signo)
 {
+	char	*exit_msg;
+
 	if (signo == SIGQUIT)
-		print_error("Quit");
+		exit_msg = "Quit";
 	else if (signo == SIGSEGV)
-		print_error("Segmentation fault");
+		exit_msg = "Segmentation fault";
+	else
+		exit_msg = "";
 	if (WCOREDUMP(wstatus))
-		print_error(" (core dumped)");
-	print_error("\n");
+		print_error("%s (core dumped)\n", exit_msg);
+	else
+		print_error("%s\n", exit_msg);
 }

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -114,7 +114,7 @@ static t_hd_st	read_heredoc(t_sh *shell, t_list **line_list, char *here_end)
 		if (shell->exit_code == TERM_BY_SIGNAL + SIGINT)
 			return (free(line), HD_ABORT);
 		if (!line)
-			return (ft_dprintf(STDERR_FILENO, ERROR_HEREDOC_UNEXPECTED_EOF,
+			return (print_error(ERROR_HEREDOC_UNEXPECTED_EOF,
 					PROGRAM_NAME, here_end), HD_SUCCESS);
 		if (ft_strcmp(line, here_end) == 0)
 			break ;

--- a/source/backend/redirection/io_file.c
+++ b/source/backend/redirection/io_file.c
@@ -60,8 +60,7 @@ static int	expand_filename(t_sh *shell, char **filename)
 		return (ft_lstclear(&expanded_list, free), ret);
 	if (ft_lstsize_non_null(expanded_list) != 1)
 	{
-		ft_dprintf(STDERR_FILENO,
-			ERROR_AMBIGUOUS_REDIRECT, PROGRAM_NAME, *filename);
+		print_error(ERROR_AMBIGUOUS_REDIRECT, PROGRAM_NAME, *filename);
 		return (ft_lstclear(&expanded_list, free), AMBIGUOUS_REDIR);
 	}
 	free(*filename);
@@ -91,7 +90,7 @@ static bool	handle_red_in(int *read_fd, char *filename)
 	fd = open(filename, O_RDONLY);
 	if (fd < 0)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: %s: ", PROGRAM_NAME, filename);
+		print_error("%s: %s: ", PROGRAM_NAME, filename);
 		perror("");
 		return (false);
 	}
@@ -106,7 +105,7 @@ static bool	handle_red_out(int *write_fd, char *filename, int o_flags)
 	fd = open(filename, o_flags, (S_IRUSR + S_IWUSR) | S_IRGRP | S_IROTH);
 	if (fd < 0)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: %s: ", PROGRAM_NAME, filename);
+		print_error("%s: %s: ", PROGRAM_NAME, filename);
 		perror("");
 		return (false);
 	}

--- a/source/backend/redirection/pipe_utils.c
+++ b/source/backend/redirection/pipe_utils.c
@@ -36,7 +36,7 @@ bool	create_pipe(t_pipe *new_pipe)
 {
 	if (new_pipe->pipe_fd[0] != -1 || new_pipe->pipe_fd[1] != -1)
 	{
-		ft_dprintf(STDERR_FILENO, "Warning: Pipe is not empty\n");
+		print_error("Warning: Pipe is not empty\n");
 		safe_close_pipe(new_pipe);
 	}
 	if (pipe(new_pipe->pipe_fd) == -1)

--- a/source/backend/redirection/stdio_bind.c
+++ b/source/backend/redirection/stdio_bind.c
@@ -6,7 +6,7 @@
 /*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 15:09:45 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:48:16 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/05/03 17:18:22 by lyeh             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ bool	save_std_io(int saved_std_io[2])
 	saved_std_io[1] = dup(STDOUT_FILENO);
 	if (saved_std_io[0] == -1 || saved_std_io[1] == -1)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		print_error("%s: ", PROGRAM_NAME);
 		perror(NULL);
 		safe_close(&saved_std_io[0]);
 		safe_close(&saved_std_io[1]);
@@ -36,7 +36,7 @@ bool	redirect_scmd_io(t_sh *shell, int *read_fd, int *write_fd)
 	if (dup2(*read_fd, STDIN_FILENO) == -1 || \
 		dup2(*write_fd, STDOUT_FILENO) == -1)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		print_error("%s: ", PROGRAM_NAME);
 		perror(NULL);
 		ret = false;
 	}
@@ -63,7 +63,7 @@ int	redirect_subshell_io(t_sh *shell, t_ct *cmd_table)
 		((read_fd != -1 && dup2(read_fd, STDIN_FILENO) == -1) || \
 		(write_fd != -1 && dup2(write_fd, STDOUT_FILENO) == -1)))
 	{
-		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		print_error("%s: ", PROGRAM_NAME);
 		perror(NULL);
 		ret = GENERAL_ERROR;
 	}
@@ -85,7 +85,7 @@ bool	restore_std_io(int saved_std_io[2])
 			error = true;
 	if (error)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: ", PROGRAM_NAME);
+		print_error("%s: ", PROGRAM_NAME);
 		perror(NULL);
 		return (false);
 	}

--- a/source/frontend/expander/bad_substitution.c
+++ b/source/frontend/expander/bad_substitution.c
@@ -73,6 +73,5 @@ static void	print_bad_substitution_error(char *str, int i)
 	}
 	else
 		start = str;
-	ft_dprintf(STDERR_FILENO, ERROR_EXPANDER_BAD_SUBSTITUTION,
-		PROGRAM_NAME, start);
+	print_error(ERROR_EXPANDER_BAD_SUBSTITUTION, PROGRAM_NAME, start);
 }

--- a/source/frontend/lexer/lexer_utils.c
+++ b/source/frontend/lexer/lexer_utils.c
@@ -32,7 +32,7 @@ void	print_missing_pair_error(char *str)
 		missing_pair = CLOSING_BRACE;
 	else
 		missing_pair = *str;
-	ft_dprintf(STDERR_FILENO, ERROR_LEXER_SYNTAX, PROGRAM_NAME, missing_pair);
+	print_error(ERROR_LEXER_SYNTAX, PROGRAM_NAME, missing_pair);
 }
 
 void	skip_operator(char *token_data, int *i)

--- a/source/frontend/parser/syntax_error.c
+++ b/source/frontend/parser/syntax_error.c
@@ -24,7 +24,7 @@ void	report_syntax_error(t_sh *shell, t_prs_data *parser_data)
 	if (!error_token)
 		error_token = "newline";
 	shell->exit_code = SYNTAX_ERROR;
-	ft_dprintf(STDERR_FILENO, ERROR_PARSER_SYNTAX, PROGRAM_NAME, error_token);
+	print_error(ERROR_PARSER_SYNTAX, PROGRAM_NAME, error_token);
 }
 
 static char	*get_error_token_data(t_list *token_list, t_list *parse_stack)

--- a/source/utils/error_utils.c
+++ b/source/utils/error_utils.c
@@ -1,0 +1,24 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   error_utils.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/03 17:14:48 by lyeh              #+#    #+#             */
+/*   Updated: 2024/05/05 13:28:52 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "defines.h"
+
+void	print_error(char *format, ...)
+{
+	char	buffer[ERROR_MAX_LEN];
+	va_list	ap;
+
+	va_start(ap, format);
+	ft_vsnprintf(buffer, ERROR_MAX_LEN, format, ap);
+	va_end(ap);
+	ft_dprintf(STDERR_FILENO, "%s", buffer);
+}

--- a/source/utils/file_utils.c
+++ b/source/utils/file_utils.c
@@ -47,7 +47,7 @@ bool	write_content_to_file(char *content, char *filename)
 void	remove_file(char *filename)
 {
 	if (unlink(filename) == -1)
-		ft_dprintf(STDERR_FILENO, ERROR_REMOVE_FILE, PROGRAM_NAME, filename);
+		print_error(ERROR_REMOVE_FILE, PROGRAM_NAME, filename);
 }
 
 bool	is_dir(char *dir)


### PR DESCRIPTION
## Solution

If multiple processes print to stderr at the same time, with `ft_dprintf()`, multiple calls to `write()` might be called.
This can cause the error messages to be interleaved.
The solution is to first use `ft_vsnprintf()` to convert the format string with all its arguments into a buffer string, and then print that string at once with one call to `write()`.

The buffer string for the error message is set to 131072 bytes.
If an error message is longer, it would get truncated.

---

## Implementation of `vsnprintf()`

#### C-99 Standard:
A va_list may be passed as an argument to
another function; if that function invokes the va_arg macro, the
value of the va_list in the calling function is indeterminate and shall be passed to the va_end
macro prior to any further reference.

It is permitted to create a pointer to a va_list and pass that pointer to another function, in which
case the original function may make further use of the original list after the other function returns.