### PR TITLE
[FIX] Fix overflow check for exit builtin and add overflow-check functions to libft

### DIFF
--- a/libraries/libft/build/libft.mk
+++ b/libraries/libft/build/libft.mk
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/16 13:33:38 by ldulling          #+#    #+#              #
-#    Updated: 2024/05/05 17:21:36 by ldulling         ###   ########.fr        #
+#    Updated: 2024/05/21 14:58:39 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -20,6 +20,7 @@ SRC		+=	$(addprefix $(DIR), \
 			ft_isalpha.c \
 			ft_isascii.c \
 			ft_isdigit.c \
+			ft_issign.c \
 			ft_isprint.c \
 			ft_isspace.c \
 			ft_tolower.c \
@@ -123,6 +124,8 @@ SRC		+=	$(addprefix $(DIR), \
 			ft_atof.c \
 			ft_atoi.c \
 			ft_atol.c \
+			ft_isoverflow_int.c \
+			ft_isoverflow_long.c \
 )
 
 # Put:

--- a/libraries/libft/inc/libft.h
+++ b/libraries/libft/inc/libft.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/24 16:17:46 by ldulling          #+#    #+#             */
-/*   Updated: 2024/03/31 23:45:05 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/21 14:58:24 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,6 +41,7 @@ int			ft_isalnum(int c);
 int			ft_isalpha(int c);
 int			ft_isascii(int c);
 int			ft_isdigit(int c);
+int			ft_issign(int c);
 int			ft_isprint(int c);
 int			ft_isspace(int c);
 int			ft_tolower(int c);
@@ -102,6 +103,8 @@ void		*ft_memset(void *s, int c, size_t n);
 double		ft_atof(const char *nptr);
 int			ft_atoi(const char *nptr);
 long		ft_atol(const char *nptr);
+bool		ft_isoverflow_int(const char *nptr);
+bool		ft_isoverflow_long(const char *nptr);
 
 \
 /* Put */

--- a/libraries/libft/src/chars/ft_issign.c
+++ b/libraries/libft/src/chars/ft_issign.c
@@ -1,34 +1,29 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_isspace.c                                       :+:      :+:    :+:   */
+/*   ft_issign.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2023/11/13 12:12:35 by ldulling          #+#    #+#             */
-/*   Updated: 2024/05/21 15:02:11 by ldulling         ###   ########.fr       */
+/*   Created: 2024/05/21 14:55:40 by ldulling          #+#    #+#             */
+/*   Updated: 2024/05/21 15:08:44 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
 /**
- * The ft_isspace function checks if the passed character is a whitespace
- * character.
- * A whitespace character is one of the following:
- *   space, form feed, new line, carriage ret, horizontal tab, vertical tab
- *   ' '    '\f'       '\n'      '\r'          '\t'            '\v'
+ * The ft_issign function checks if the passed character is a sign character
+ * ('+' or '-').
  *
  * @param c    The character to check.
  *
- * @return     Returns 1 if the character is a whitespace character,
- *             0 otherwise.
+ * @return     Returns 1 if the character is a sign character, 0 otherwise.
  *
  */
-int	ft_isspace(int c)
+int	ft_issign(int c)
 {
-	if (ft_strchr(WHITESPACE, c))
+	if (c == '-' || c == '+')
 		return (1);
-	else
-		return (0);
+	return (0);
 }

--- a/libraries/libft/src/numbers/ft_isoverflow_int.c
+++ b/libraries/libft/src/numbers/ft_isoverflow_int.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/21 14:39:46 by ldulling          #+#    #+#             */
-/*   Updated: 2024/05/21 15:09:39 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/21 19:00:00 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ bool	ft_isoverflow_int(const char *nptr)
 {
 	int		i;
 	char	*int_max;
+	int		int_max_len;
 	int		num_len;
 
 	i = 0;
@@ -41,6 +42,7 @@ bool	ft_isoverflow_int(const char *nptr)
 		int_max = "2147483648";
 	else
 		int_max = "2147483647";
+	int_max_len = ft_strlen(int_max);
 	if (ft_issign(nptr[i]))
 		i++;
 	while (nptr[i] == '0')
@@ -48,8 +50,8 @@ bool	ft_isoverflow_int(const char *nptr)
 	num_len = 0;
 	while (ft_isdigit(nptr[i + num_len]))
 		num_len++;
-	if (num_len > (int)ft_strlen(int_max) || \
-		ft_strncmp(&nptr[i], int_max, num_len) > 0)
+	if ((num_len == int_max_len && ft_strncmp(&nptr[i], int_max, num_len) > 0)
+		|| num_len > int_max_len)
 		return (true);
 	return (false);
 }

--- a/libraries/libft/src/numbers/ft_isoverflow_int.c
+++ b/libraries/libft/src/numbers/ft_isoverflow_int.c
@@ -1,0 +1,55 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_isoverflow_int.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/21 14:39:46 by ldulling          #+#    #+#             */
+/*   Updated: 2024/05/21 15:09:39 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+/**
+ * The ft_isoverflow_int function checks if the passed string represents a
+ * number that would cause an overflow if converted to an integer.
+ *
+ * The function skips any leading whitespace and checks for a sign character
+ * ('+' or '-').
+ * It then compares the number part of the string with the maximum positive
+ * integer value (2147483647) or the maximum negative integer value
+ * (-2147483648) depending on the sign.
+ *
+ * @param nptr    The null-terminated string to check.
+ *
+ * @return        Returns true if the string represents a number that would
+ *                cause an overflow, false otherwise.
+ *
+ */
+bool	ft_isoverflow_int(const char *nptr)
+{
+	int		i;
+	char	*int_max;
+	int		num_len;
+
+	i = 0;
+	while (nptr[i] && ft_strchr(WHITESPACE, nptr[i]))
+		i++;
+	if (nptr[i] == '-')
+		int_max = "2147483648";
+	else
+		int_max = "2147483647";
+	if (ft_issign(nptr[i]))
+		i++;
+	while (nptr[i] == '0')
+		i++;
+	num_len = 0;
+	while (ft_isdigit(nptr[i + num_len]))
+		num_len++;
+	if (num_len > (int)ft_strlen(int_max) || \
+		ft_strncmp(&nptr[i], int_max, num_len) > 0)
+		return (true);
+	return (false);
+}

--- a/libraries/libft/src/numbers/ft_isoverflow_long.c
+++ b/libraries/libft/src/numbers/ft_isoverflow_long.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/21 14:39:46 by ldulling          #+#    #+#             */
-/*   Updated: 2024/05/21 15:17:02 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/21 19:05:36 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,6 +32,7 @@ bool	ft_isoverflow_long(const char *nptr)
 {
 	int		i;
 	char	*long_max;
+	int		long_max_len;
 	int		num_len;
 
 	i = 0;
@@ -41,6 +42,7 @@ bool	ft_isoverflow_long(const char *nptr)
 		long_max = "9223372036854775808";
 	else
 		long_max = "9223372036854775807";
+	long_max_len = ft_strlen(long_max);
 	if (ft_issign(nptr[i]))
 		i++;
 	while (nptr[i] == '0')
@@ -48,8 +50,8 @@ bool	ft_isoverflow_long(const char *nptr)
 	num_len = 0;
 	while (ft_isdigit(nptr[i + num_len]))
 		num_len++;
-	if (num_len > (int)ft_strlen(long_max) || \
-		ft_strncmp(&nptr[i], long_max, num_len) > 0)
+	if ((num_len == long_max_len && ft_strncmp(&nptr[i], long_max, num_len) > 0)
+		|| num_len > long_max_len)
 		return (true);
 	return (false);
 }

--- a/libraries/libft/src/numbers/ft_isoverflow_long.c
+++ b/libraries/libft/src/numbers/ft_isoverflow_long.c
@@ -1,0 +1,55 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_isoverflow_long.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/21 14:39:46 by ldulling          #+#    #+#             */
+/*   Updated: 2024/05/21 15:17:02 by ldulling         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+
+/**
+ * The ft_isoverflow_long function checks if the passed string represents a
+ * number that would cause an overflow if converted to a long integer.
+ *
+ * The function skips any leading whitespace and checks for a sign character
+ * ('+' or '-').
+ * It then compares the number part of the string with the maximum positive
+ * long integer value (9223372036854775807) or the maximum negative long integer
+ * value (-9223372036854775808) depending on the sign.
+ *
+ * @param nptr    The null-terminated string to check.
+ *
+ * @return        Returns true if the string represents a number that would
+ *                cause an overflow, false otherwise.
+ *
+ */
+bool	ft_isoverflow_long(const char *nptr)
+{
+	int		i;
+	char	*long_max;
+	int		num_len;
+
+	i = 0;
+	while (nptr[i] && ft_strchr(WHITESPACE, nptr[i]))
+		i++;
+	if (nptr[i] == '-')
+		long_max = "9223372036854775808";
+	else
+		long_max = "9223372036854775807";
+	if (ft_issign(nptr[i]))
+		i++;
+	while (nptr[i] == '0')
+		i++;
+	num_len = 0;
+	while (ft_isdigit(nptr[i + num_len]))
+		num_len++;
+	if (num_len > (int)ft_strlen(long_max) || \
+		ft_strncmp(&nptr[i], long_max, num_len) > 0)
+		return (true);
+	return (false);
+}

--- a/source/backend/builtins/exit/exit_utils.c
+++ b/source/backend/builtins/exit/exit_utils.c
@@ -6,16 +6,14 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 17:40:30 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/20 00:36:35 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/21 15:05:47 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "utils.h"
 #include "builtins.h"
+#include "utils.h"
 
 static bool	valid_number(char *str);
-static bool	is_sign(char c);
-static bool	is_atol_overflow(char *str);
 
 t_exit_err	get_args_error(char *args[])
 {
@@ -24,7 +22,7 @@ t_exit_err	get_args_error(char *args[])
 	if (!args || !args[1])
 		return (EX_NO_ARGS);
 	error_type = EX_NORM_ARGS;
-	if (!valid_number(args[1]) || is_atol_overflow(args[1]))
+	if (!valid_number(args[1]) || ft_isoverflow_long(args[1]))
 		error_type = EX_NOT_NUMERIC;
 	else if (args[2])
 		error_type = EX_TOO_MANY_ARGS;
@@ -40,7 +38,7 @@ static bool	valid_number(char *str)
 	i = 0;
 	while (str[i] && ft_strchr(WHITESPACE, str[i]))
 		i++;
-	if (is_sign(str[i]))
+	if (ft_issign(str[i]))
 		i++;
 	if (!ft_isdigit(str[i]))
 		return (false);
@@ -56,37 +54,4 @@ static bool	valid_number(char *str)
 	if (str[i])
 		return (false);
 	return (true);
-}
-
-static bool	is_sign(char c)
-{
-	if (c == '+' || c == '-')
-		return (true);
-	return (false);
-}
-
-static bool	is_atol_overflow(char *str)
-{
-	int		i;
-	char	*long_max;
-	int		num_len;
-
-	i = 0;
-	while (str[i] && ft_strchr(WHITESPACE, str[i]))
-		i++;
-	if (str[i] == '-')
-		long_max = "9223372036854775808";
-	else
-		long_max = "9223372036854775807";
-	if (is_sign(str[i]))
-		i++;
-	while (str[i] == '0')
-		i++;
-	num_len = 0;
-	while (ft_isdigit(str[i + num_len]))
-		num_len++;
-	if (num_len > (int)ft_strlen(long_max) || \
-		ft_strncmp(&str[i], long_max, num_len) > 0)
-		return (true);
-	return (false);
 }


### PR DESCRIPTION
The overflow check was wrong in a case like `exit 93`. It reported `numeric argument required`.
This was because the overflow check did `ft_strncmp()` even if the length of the number_string is less than the long_max string.

As for putting the functions into libft, I think it's good to put them into libft bc I also need them for philosophers and we will also be able to use them for miniRT.