### PR TITLE
[FIX] Fix `SIGABRT` misuse by switching to `SIGUSR1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ https://starchart.cc/LeaYeh/minishell
 |            |             |                        | Handled `ctrl-D` as `EOF` as bash behavior.                                                              | ✅      |
 |            |             |                        | Handled `ctrl-\\` as `SIGQUIT` as bash behavior.                                                         | ✅      |
 |            |             | Exception Handling     | Ignored `SIGPIPE` in internal process and set it back as default in external commands sub-process.       | ✅      |
-|            |             |                        | Used `SIGABRT` and `SIGTERM` to raise internal critical error to all related process and handle it depends on scenario.       | ✅      |
+|            |             |                        | Used `SIGUSR1` and `SIGTERM` to raise internal critical error to all related process and handle it depends on scenario.       | ✅      |
 
 
 # DevOPS Spirit
@@ -564,7 +564,7 @@ Using signals for exception handling in shell programming, similar to Bash's des
     - By utilizing signals, we can promptly broadcast error messages and take appropriate actions, such as terminating subprocesses or halting execution, depending on the severity of the error.
 2. Ensuring Subprocess Termination:
     - In the event of a critical error, it's crucial to ensure that all subprocesses spawned by the shell are terminated to prevent any lingering processes that could potentially cause issues or consume resources.
-    - Signals like `SIGABRT` and `SIGTERM` are used to terminate subprocesses gracefully, ensuring that they clean up resources and exit properly.
+    - Signals like `SIGUSR1` and `SIGTERM` are used to terminate subprocesses gracefully, ensuring that they clean up resources and exit properly.
 3. Providing Feedback to Users:
     - Exception handling using signals allows us to provide feedback to users about the occurrence of critical errors. We can print error messages, indicating the nature of the error and any relevant details, enhancing user understanding and troubleshooting.
 4. Facilitating Controlled Shutdown:
@@ -572,7 +572,7 @@ Using signals for exception handling in shell programming, similar to Bash's des
 
 Let's take a closer look at how signals are utilized in our source code:
 
-- `raise_error_and_escape`: This function raises an error message and initiates an abort signal (`SIGABRT`) to terminate all subprocesses. It's used for critical errors where immediate termination is necessary.
+- `raise_error_and_escape`: This function raises an error message and initiates an abort signal (`SIGUSR1`) to terminate all subprocesses. It's used for critical errors where immediate termination is necessary.
 - `raise_error_to_all_subprocess`: Similar to the previous function, this one raises an error message and sends a termination signal (`SIGTERM`) to all subprocesses. It's used when the error is critical but allows for a graceful shutdown.
 - `raise_error_to_own_subprocess` and `signal_to_all_subprocess`: These functions are used for handling errors within subprocesses. They ensure that subprocesses receive termination signals (`SIGTERM`) and facilitate controlled shutdowns.
 

--- a/include/signals.h
+++ b/include/signals.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signals.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 18:35:55 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/18 18:36:10 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/05/21 23:10:49 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,6 @@
 
 void	handle_signal_std(int signo, siginfo_t *info, void *context);
 void	handle_signal_record(int signo, siginfo_t *info, void *context);
-void	handle_signal_heredoc(int signo, siginfo_t *info, void *context);
 void	setup_signal(t_sh *shell, int signo, t_sig state);
 void	raise_error_and_escape(t_sh *shell, char *msg);
 void	raise_error_to_all_subprocess(t_sh *shell, int exit_code, char *msg);

--- a/source/backend/executor/external_cmd.c
+++ b/source/backend/executor/external_cmd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   external_cmd.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 15:17:06 by lyeh              #+#    #+#             */
-/*   Updated: 2024/05/03 17:18:03 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,7 @@ static void	reset_external_signal_handler(t_sh *shell)
 	setup_signal(shell, SIGINT, SIG_DEFAULT);
 	setup_signal(shell, SIGQUIT, SIG_DEFAULT);
 	setup_signal(shell, SIGTERM, SIG_DEFAULT);
-	setup_signal(shell, SIGABRT, SIG_DEFAULT);
+	setup_signal(shell, SIGUSR1, SIG_DEFAULT);
 }
 
 static void	handle_exec_error(t_sh *shell, char *exec_path)

--- a/source/shell/init.c
+++ b/source/shell/init.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   init.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 20:06:39 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/21 17:36:42 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,7 +36,7 @@ bool	init_shell(t_sh *shell)
 	handle_signal_std(0, NULL, shell);
 	handle_signal_record(0, NULL, shell);
 	setup_signal(shell, SIGINT, SIG_STANDARD);
-	setup_signal(shell, SIGABRT, SIG_STANDARD);
+	setup_signal(shell, SIGUSR1, SIG_STANDARD);
 	setup_signal(shell, SIGTERM, SIG_STANDARD);
 	setup_signal(shell, SIGQUIT, SIG_IGNORE);
 	return (true);

--- a/source/signal/exception_broadcaster.c
+++ b/source/signal/exception_broadcaster.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exception_broadcaster.c                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 17:45:41 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/18 17:48:59 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ void	raise_error_and_escape(t_sh *shell, char *msg)
 {
 	if (msg)
 		print_error(STY_RED"%s: error: %s\n"STY_RES, PROGRAM_NAME, msg);
-	kill(-shell->pid, SIGABRT);
+	kill(-shell->pid, SIGUSR1);
 }
 
 void	raise_error_to_all_subprocess(t_sh *shell, int exit_code, char *msg)
@@ -28,7 +28,7 @@ void	raise_error_to_all_subprocess(t_sh *shell, int exit_code, char *msg)
 	if (msg)
 		print_error(STY_RED"%s: error: %s\n"STY_RES, PROGRAM_NAME, msg);
 	setup_signal(shell, SIGINT, SIG_STANDARD);
-	setup_signal(shell, SIGABRT, SIG_STANDARD);
+	setup_signal(shell, SIGUSR1, SIG_STANDARD);
 	setup_signal(shell, SIGQUIT, SIG_IGNORE);
 	kill(-shell->pid, SIGTERM);
 }
@@ -39,7 +39,7 @@ void	raise_error_to_own_subprocess(t_sh *shell, int exit_code, char *msg)
 	if (msg)
 		print_error(STY_RED"%s: error: %s\n"STY_RES, PROGRAM_NAME, msg);
 	setup_signal(shell, SIGINT, SIG_STANDARD);
-	setup_signal(shell, SIGABRT, SIG_STANDARD);
+	setup_signal(shell, SIGUSR1, SIG_STANDARD);
 	setup_signal(shell, SIGTERM, SIG_STANDARD);
 	setup_signal(shell, SIGQUIT, SIG_IGNORE);
 	signal_to_all_subprocess(shell, SIGTERM);

--- a/source/signal/signal_handler.c
+++ b/source/signal/signal_handler.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   signal_handler.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lyeh <lyeh@student.42vienna.com>           +#+  +:+       +#+        */
+/*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 17:46:19 by lyeh              #+#    #+#             */
-/*   Updated: 2024/03/19 10:27:36 by lyeh             ###   ########.fr       */
+/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ void	handle_signal_std(int signo, siginfo_t *info, void *context)
 		rl_on_new_line();
 		rl_replace_line("", 0);
 	}
-	else if (signo == SIGABRT)
+	else if (signo == SIGUSR1)
 	{
 		if (shell->subshell_level == 0)
 			clean_and_exit_shell(


### PR DESCRIPTION
While `SIGABRT` defaults to termination, it is also expected to produce a core dump. If we don't do that, we would change the expected behavior of `SIGABRT`.
An example usage that produces a `SIGABRT` signal is the `abort()` function.
Note: The `abort()` function would usually still work as expected (from the `abort()` manual):
> If the SIGABRT signal is ignored, or caught by a handler that returns, the abort() function will still terminate the process.  It does this by restoring the default disposition for SIGABRT and then raising the signal for a second time.

However, in our case our signal handler for `SIGABRT` does not return but exit, hence the abort function never gets the chance to send the signal a second time with default behavior.

---

- Also remove prototype of non-existing function in signals.h.