### PR TITLE
[CHORE] Error-macro and `setup_signal()` simplification

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 15:56:26 by lyeh              #+#    #+#             */
-/*   Updated: 2024/05/05 12:37:49 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/30 23:48:09 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -76,8 +76,7 @@
 # define CMD_NOT_FOUND		127
 # define UNEXPECT_EXIT		128
 # define TERM_BY_SIGNAL		128
-# define PREPROCESS_ERROR	195
-# define BUILTIN_ERROR		196
+# define BUILTIN_ERROR		195
 # define FORK_ERROR			254
 
 /* Text-Style Escape Codes */

--- a/include/defines.h
+++ b/include/defines.h
@@ -76,7 +76,6 @@
 # define CMD_NOT_FOUND		127
 # define UNEXPECT_EXIT		128
 # define TERM_BY_SIGNAL		128
-# define BUILTIN_ERROR		195
 # define FORK_ERROR			254
 
 /* Text-Style Escape Codes */

--- a/include/signals.h
+++ b/include/signals.h
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 18:35:55 by lyeh              #+#    #+#             */
-/*   Updated: 2024/05/21 23:10:49 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/01 11:50:09 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@
 
 void	handle_signal_std(int signo, siginfo_t *info, void *context);
 void	handle_signal_record(int signo, siginfo_t *info, void *context);
-void	setup_signal(t_sh *shell, int signo, t_sig state);
+void	setup_signal(int signo, t_sig state);
 void	raise_error_and_escape(t_sh *shell, char *msg);
 void	raise_error_to_all_subprocess(t_sh *shell, int exit_code, char *msg);
 void	raise_error_to_own_subprocess(t_sh *shell, int exit_code, char *msg);

--- a/source/backend/builtins/cd/cd.c
+++ b/source/backend/builtins/cd/cd.c
@@ -34,6 +34,6 @@ int	exec_cd(char *args[], t_list **env_list)
 	if (args[1] && ft_strcmp(args[1], "-") == 0)
 		ft_printf("%s\n", target_dir);
 	if (!update_pwd_env(env_list, new_pwd))
-		return (free(new_pwd), BUILTIN_ERROR);
+		return (free(new_pwd), MALLOC_ERROR);
 	return (EXIT_SUCCESS);
 }

--- a/source/backend/builtins/cd/cd_errors.c
+++ b/source/backend/builtins/cd/cd_errors.c
@@ -18,7 +18,7 @@ int	handle_cd_error(int error, char *target_dir)
 	{
 		print_error("%s: cd: ", PROGRAM_NAME);
 		perror(NULL);
-		return (BUILTIN_ERROR);
+		return (MALLOC_ERROR);
 	}
 	print_error("%s: cd: %s: ", PROGRAM_NAME, target_dir);
 	perror(NULL);

--- a/source/backend/builtins/cd/component_list_utils.c
+++ b/source/backend/builtins/cd/component_list_utils.c
@@ -19,7 +19,7 @@ int	check_cmpnt_node_path(
 
 	path = convert_cmpnt_node_to_path(cmpnt_list, cmpnt_node);
 	if (!path)
-		return (BUILTIN_ERROR);
+		return (MALLOC_ERROR);
 	if (ft_strlen(path) + 1 <= PATH_MAX)
 	{
 		if (!check_dir(path, target_dir))

--- a/source/backend/builtins/cd/path.c
+++ b/source/backend/builtins/cd/path.c
@@ -29,7 +29,7 @@ int	set_final_path(char **final_path, char **new_pwd, char *target_dir)
 	*final_path = try_to_convert_abs_to_rel_path(*new_pwd, pwd);
 	free(pwd);
 	if (!*final_path)
-		return (free(*new_pwd), BUILTIN_ERROR);
+		return (free(*new_pwd), MALLOC_ERROR);
 	if (ft_strlen(*final_path) + 1 > PATH_MAX)
 	{
 		free(*final_path);
@@ -38,7 +38,7 @@ int	set_final_path(char **final_path, char **new_pwd, char *target_dir)
 			return (free(*new_pwd), ret);
 	}
 	if (!ensure_path_not_empty(final_path))
-		return (free(*new_pwd), BUILTIN_ERROR);
+		return (free(*new_pwd), MALLOC_ERROR);
 	return (SUCCESS);
 }
 
@@ -52,7 +52,7 @@ static int	simplify_path(char **new_path, char *target_dir, char *pwd)
 	else
 		cmpnt_list = create_cmpnt_list(target_dir);
 	if (!cmpnt_list)
-		return (BUILTIN_ERROR);
+		return (MALLOC_ERROR);
 	ret = handle_dot_cmpnts(&cmpnt_list, target_dir);
 	if (ret != SUCCESS)
 		return (ft_lstclear_d(&cmpnt_list, free), ret);
@@ -60,7 +60,7 @@ static int	simplify_path(char **new_path, char *target_dir, char *pwd)
 			cmpnt_list, ft_lstlast_d(cmpnt_list));
 	ft_lstclear_d(&cmpnt_list, free);
 	if (!*new_path)
-		return (BUILTIN_ERROR);
+		return (MALLOC_ERROR);
 	return (SUCCESS);
 }
 

--- a/source/backend/builtins/export/export.c
+++ b/source/backend/builtins/export/export.c
@@ -33,7 +33,7 @@ int	exec_export(char *args[], t_list **env_list)
 			ret = GENERAL_ERROR;
 		}
 		else if (!handle_var_export(args[i], env_list))
-			return (BUILTIN_ERROR);
+			return (MALLOC_ERROR);
 		i++;
 	}
 	return (ret);

--- a/source/backend/builtins/export/export_output.c
+++ b/source/backend/builtins/export/export_output.c
@@ -46,7 +46,7 @@ int	print_exported_env(t_list *env_list)
 		return (SUCCESS);
 	export_printout = (char *)malloc(total_len + 1);
 	if (!export_printout)
-		return (BUILTIN_ERROR);
+		return (MALLOC_ERROR);
 	fill_export_printout(env_list, export_printout, prefix_len, format_len);
 	ft_printf("%s", export_printout);
 	free(export_printout);

--- a/source/backend/executor/builtin_cmd.c
+++ b/source/backend/executor/builtin_cmd.c
@@ -42,8 +42,8 @@ void	handle_builtin(t_sh *shell, t_list_d **cmd_table_node)
 		safe_redirect_io_and_exec_builtin(shell);
 	else if (shell->final_cmd_table->simple_cmd[0])
 		redirect_io_and_exec_builtin(shell);
-	if (shell->exit_code == BUILTIN_ERROR)
-		raise_error_to_own_subprocess(shell, MALLOC_ERROR, NULL);
+	if (shell->exit_code == MALLOC_ERROR)
+		raise_error_to_own_subprocess(shell, shell->exit_code, NULL);
 	*cmd_table_node = (*cmd_table_node)->next;
 }
 

--- a/source/backend/executor/builtin_cmd.c
+++ b/source/backend/executor/builtin_cmd.c
@@ -87,7 +87,7 @@ static void	exec_builtin_cmd(t_sh *shell)
 {
 	t_fct	*final_cmd_table;
 
-	setup_signal(shell, SIGPIPE, SIG_IGNORE);
+	setup_signal(SIGPIPE, SIG_IGNORE);
 	final_cmd_table = shell->final_cmd_table;
 	if (ft_strcmp(final_cmd_table->simple_cmd[0], "env") == 0)
 		shell->exit_code = exec_env(final_cmd_table->env);
@@ -109,5 +109,5 @@ static void	exec_builtin_cmd(t_sh *shell)
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "~") == 0 && \
 			shell->is_interactive)
 		shell->exit_code = exec_easter_egg();
-	setup_signal(shell, SIGPIPE, SIG_STANDARD);
+	setup_signal(SIGPIPE, SIG_STANDARD);
 }

--- a/source/backend/executor/external_cmd.c
+++ b/source/backend/executor/external_cmd.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/19 15:17:06 by lyeh              #+#    #+#             */
-/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/01 11:51:52 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 #include "signals.h"
 
 static bool	check_execfile_exist(char *exec_path, char *cmd_name);
-static void	reset_external_signal_handler(t_sh *shell);
+static void	reset_external_signal_handler(void);
 static void	handle_exec_error(t_sh *shell, char *exec_path);
 
 void	handle_external_cmd(t_sh *shell, t_ct *cmd_table)
@@ -40,7 +40,7 @@ void	handle_external_cmd(t_sh *shell, t_ct *cmd_table)
 	if (!redirect_scmd_io(shell, &final_cmd_table->read_fd,
 			&final_cmd_table->write_fd))
 		clean_and_exit_shell(shell, GENERAL_ERROR, NULL);
-	reset_external_signal_handler(shell);
+	reset_external_signal_handler();
 	execve(final_cmd_table->exec_path, final_cmd_table->simple_cmd,
 		final_cmd_table->env);
 	handle_exec_error(shell, final_cmd_table->exec_path);
@@ -58,12 +58,12 @@ static bool	check_execfile_exist(char *exec_path, char *cmd_name)
 	return (false);
 }
 
-static void	reset_external_signal_handler(t_sh *shell)
+static void	reset_external_signal_handler(void)
 {
-	setup_signal(shell, SIGINT, SIG_DEFAULT);
-	setup_signal(shell, SIGTERM, SIG_DEFAULT);
-	setup_signal(shell, SIGUSR1, SIG_DEFAULT);
-	setup_signal(shell, SIGQUIT, SIG_DEFAULT);
+	setup_signal(SIGINT, SIG_DEFAULT);
+	setup_signal(SIGTERM, SIG_DEFAULT);
+	setup_signal(SIGUSR1, SIG_DEFAULT);
+	setup_signal(SIGQUIT, SIG_DEFAULT);
 }
 
 static void	handle_exec_error(t_sh *shell, char *exec_path)

--- a/source/backend/executor/pipeline_process.c
+++ b/source/backend/executor/pipeline_process.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/01 19:32:12 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/04 22:48:15 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/01 11:50:48 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,19 +30,19 @@ void	fork_pipeline(t_sh *shell, t_list_d **cmd_table_node)
 	}
 	else if (shell->subshell_pid == 0)
 	{
-		setup_signal(shell, SIGINT, SIG_IGNORE);
-		setup_signal(shell, SIGTERM, SIG_STANDARD);
+		setup_signal(SIGINT, SIG_IGNORE);
+		setup_signal(SIGTERM, SIG_STANDARD);
 		shell->subshell_level += 1;
 		handle_pipes_child(&shell->new_pipe, &shell->old_pipe);
 		exec_pipeline(shell, cmd_table_node);
 	}
 	else
 	{
-		setup_signal(shell, SIGINT, SIG_RECORD);
+		setup_signal(SIGINT, SIG_RECORD);
 		move_past_pipeline(cmd_table_node);
 		handle_end_of_pipeline(shell, cmd_table_node);
 		shell->subshell_pid = -1;
-		setup_signal(shell, SIGINT, SIG_STANDARD);
+		setup_signal(SIGINT, SIG_STANDARD);
 	}
 }
 

--- a/source/frontend/lexer/lexer.c
+++ b/source/frontend/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/12 08:31:35 by codespace         #+#    #+#             */
-/*   Updated: 2024/01/07 14:09:24 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/30 23:48:44 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,18 +21,18 @@ bool	lexer(t_sh *shell)
 	if (!create_token_data_list(&token_data_list, shell->input_line))
 	{
 		ft_lstclear(&token_data_list, free);
-		clean_and_exit_shell(shell, PREPROCESS_ERROR, "lexer malloc failed");
+		clean_and_exit_shell(shell, MALLOC_ERROR, "lexer malloc failed");
 	}
 	if (!token_data_list)
 		return (false);
 	if (!create_token_list(&shell->token_list, &token_data_list))
 	{
 		ft_lstclear(&token_data_list, free);
-		clean_and_exit_shell(shell, PREPROCESS_ERROR, "lexer malloc failed");
+		clean_and_exit_shell(shell, MALLOC_ERROR, "lexer malloc failed");
 	}
 	set_token_type(shell->token_list);
 	finetune_token_list(shell->token_list);
 	if (!append_end_node(&shell->token_list))
-		clean_and_exit_shell(shell, PREPROCESS_ERROR, "lexer malloc failed");
+		clean_and_exit_shell(shell, MALLOC_ERROR, "lexer malloc failed");
 	return (true);
 }

--- a/source/frontend/parser/parser.c
+++ b/source/frontend/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/11 17:28:20 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/08 18:04:43 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/30 23:49:06 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,14 +22,14 @@ bool	parser(t_sh *shell)
 	t_prs_data	parser_data;
 
 	if (!init_parser_data(&parser_data, shell->token_list))
-		clean_and_exit_shell(shell, PREPROCESS_ERROR, "parser malloc failed");
+		clean_and_exit_shell(shell, MALLOC_ERROR, "parser malloc failed");
 	if (!parse(shell, &parser_data))
 		return (free_parser_data(&parser_data), false);
 	free_parser_data(&parser_data);
 	shell->cmd_table_list = build_cmd_table_list(shell->token_list);
 	if (!shell->cmd_table_list)
 		clean_and_exit_shell(
-			shell, PREPROCESS_ERROR, "build cmd table malloc failed");
+			shell, MALLOC_ERROR, "build cmd table malloc failed");
 	ft_lstclear(&shell->token_list, (void *)free_token);
 	return (true);
 }
@@ -45,9 +45,10 @@ static bool	parse(t_sh *shell, t_prs_data *parser_data)
 				get_state_from_stack(parser_data->state_stack),
 				(t_prs_elem)get_token_type_from_list(parser_data->token_list),
 				A_SHIFT | A_REDUCE | A_ACCEPT))
-			(free_parser_data(parser_data),
-				clean_and_exit_shell(
-					shell, PREPROCESS_ERROR, "parser malloc failed"));
+		{
+			free_parser_data(parser_data);
+			clean_and_exit_shell(shell, MALLOC_ERROR, "parser malloc failed");
+		}
 		if (!pt_entry)
 			return (report_syntax_error(shell, parser_data), false);
 		if (pt_entry->action == A_ACCEPT)
@@ -56,8 +57,7 @@ static bool	parse(t_sh *shell, t_prs_data *parser_data)
 		{
 			free(pt_entry);
 			free_parser_data(parser_data);
-			clean_and_exit_shell(
-				shell, PREPROCESS_ERROR, "parser malloc failed");
+			clean_and_exit_shell(shell, MALLOC_ERROR, "parser malloc failed");
 		}
 		ft_free_and_null((void **)&pt_entry);
 	}

--- a/source/main.c
+++ b/source/main.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 16:09:49 by lyeh              #+#    #+#             */
-/*   Updated: 2024/04/03 13:55:43 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/05/30 23:54:25 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ int	main(void)
 	t_sh	shell;
 
 	if (!DEFINITIONS_OK || !init_shell(&shell))
-		raise_error_and_escape(&shell, "init shell failed");
+		clean_and_exit_shell(&shell, MALLOC_ERROR, "init shell failed");
 	print_welcome_msg(&shell);
 	while (true)
 	{

--- a/source/shell/init.c
+++ b/source/shell/init.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/12/08 20:06:39 by lyeh              #+#    #+#             */
-/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/01 11:50:48 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,9 +35,9 @@ bool	init_shell(t_sh *shell)
 		return (false);
 	handle_signal_std(0, NULL, shell);
 	handle_signal_record(0, NULL, shell);
-	setup_signal(shell, SIGINT, SIG_STANDARD);
-	setup_signal(shell, SIGTERM, SIG_STANDARD);
-	setup_signal(shell, SIGUSR1, SIG_STANDARD);
-	setup_signal(shell, SIGQUIT, SIG_IGNORE);
+	setup_signal(SIGINT, SIG_STANDARD);
+	setup_signal(SIGTERM, SIG_STANDARD);
+	setup_signal(SIGUSR1, SIG_STANDARD);
+	setup_signal(SIGQUIT, SIG_IGNORE);
 	return (true);
 }

--- a/source/signal/exception_broadcaster.c
+++ b/source/signal/exception_broadcaster.c
@@ -6,7 +6,7 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 17:45:41 by lyeh              #+#    #+#             */
-/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/01 11:50:48 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,9 +27,9 @@ void	raise_error_to_all_subprocess(t_sh *shell, int exit_code, char *msg)
 	shell->exit_code = exit_code;
 	if (msg)
 		print_error(STY_RED"%s: error: %s\n"STY_RES, PROGRAM_NAME, msg);
-	setup_signal(shell, SIGINT, SIG_STANDARD);
-	setup_signal(shell, SIGUSR1, SIG_STANDARD);
-	setup_signal(shell, SIGQUIT, SIG_IGNORE);
+	setup_signal(SIGINT, SIG_STANDARD);
+	setup_signal(SIGUSR1, SIG_STANDARD);
+	setup_signal(SIGQUIT, SIG_IGNORE);
 	kill(-shell->pid, SIGTERM);
 }
 
@@ -38,10 +38,10 @@ void	raise_error_to_own_subprocess(t_sh *shell, int exit_code, char *msg)
 	shell->exit_code = exit_code;
 	if (msg)
 		print_error(STY_RED"%s: error: %s\n"STY_RES, PROGRAM_NAME, msg);
-	setup_signal(shell, SIGINT, SIG_STANDARD);
-	setup_signal(shell, SIGTERM, SIG_STANDARD);
-	setup_signal(shell, SIGUSR1, SIG_STANDARD);
-	setup_signal(shell, SIGQUIT, SIG_IGNORE);
+	setup_signal(SIGINT, SIG_STANDARD);
+	setup_signal(SIGTERM, SIG_STANDARD);
+	setup_signal(SIGUSR1, SIG_STANDARD);
+	setup_signal(SIGQUIT, SIG_IGNORE);
 	signal_to_all_subprocess(shell, SIGTERM);
 	kill(getpid_from_proc(), SIGTERM);
 }

--- a/source/signal/signal_handler.c
+++ b/source/signal/signal_handler.c
@@ -6,19 +6,18 @@
 /*   By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/18 17:46:19 by lyeh              #+#    #+#             */
-/*   Updated: 2024/06/01 11:03:14 by ldulling         ###   ########.fr       */
+/*   Updated: 2024/06/01 11:53:43 by ldulling         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "signals.h"
 #include "clean.h"
 
-void	setup_signal(t_sh *shell, int signo, t_sig state)
+void	setup_signal(int signo, t_sig state)
 {
 	struct sigaction	sa;
 
-	if (sigemptyset(&sa.sa_mask) == -1)
-		clean_and_exit_shell(shell, PREPROCESS_ERROR, "sigemptyset failed");
+	sigemptyset(&sa.sa_mask);
 	sa.sa_flags = SA_RESTART | SA_SIGINFO;
 	if (state == SIG_DEFAULT)
 		sa.sa_handler = SIG_DFL;


### PR DESCRIPTION
- **Remove unnecessary protection for `sigemptyset()` failure.**
  It is not necessary to protect `sigemptyset()` since the only possible failure is when passing `NULL` to it which would set errno to `EINVAL`.
  Here is the source code of `sigemptyset()`:
  ```c
  /* Clear all signals from SET.  */
  int
  sigemptyset (sigset_t *set)
  {
    if (set == NULL)
      {
        __set_errno (EINVAL);
        return -1;
      }
    __sigemptyset (set);
    return 0;
  }
  ```
- **Replace `PREPROCESS_ERROR` with `MALLOC_ERROR`.**
  I tested bash and the exit code when its malloc fails in the parsing is also `2`.
- **Replace `BUILTIN_ERROR` with `MALLOC_ERROR`.**
  `BUILTIN_ERROR`s were only used where anywhere outside of builtins `MALLOC_ERROR` would be used.
  And the value of `BUILTIN_ERROR` was relatively arbitrary too.