### PR TITLE
[REFACTOR] Prevent mixed error messages by standardizing how errors are printed

### DIFF
--- a/source/backend/builtins/cd/cd_errors.c
+++ b/source/backend/builtins/cd/cd_errors.c
@@ -16,11 +16,9 @@ int	handle_cd_error(int error, char *target_dir)
 {
 	if (error == ENOMEM || error == EIO)
 	{
-		print_error("%s: cd: ", PROGRAM_NAME);
-		perror(NULL);
+		print_error("%s: cd: %s\n", PROGRAM_NAME, strerror(error));
 		return (MALLOC_ERROR);
 	}
-	print_error("%s: cd: %s: ", PROGRAM_NAME, target_dir);
-	perror(NULL);
+	print_error("%s: cd: %s: %s\n", PROGRAM_NAME, target_dir, strerror(error));
 	return (GENERAL_ERROR);
 }

--- a/source/backend/builtins/cd/cd_utils.c
+++ b/source/backend/builtins/cd/cd_utils.c
@@ -17,8 +17,7 @@ bool	check_dir(char *dir, char *target_dir)
 {
 	if (is_dir(dir))
 		return (true);
-	print_error("%s: cd: %s: ", PROGRAM_NAME, target_dir);
-	perror(NULL);
+	print_error("%s: cd: %s: %s\n", PROGRAM_NAME, target_dir, strerror(errno));
 	return (false);
 }
 

--- a/source/backend/builtins/pwd.c
+++ b/source/backend/builtins/pwd.c
@@ -17,8 +17,7 @@ int	exec_pwd(t_sh *shell)
 	shell->builtin_allocation = getcwd(NULL, 0);
 	if (!shell->builtin_allocation)
 	{
-		print_error("%s: %s: ", PROGRAM_NAME, "pwd");
-		perror(NULL);
+		print_error("%s: %s: ", PROGRAM_NAME, "pwd", strerror(errno));
 		if (errno == ENOMEM)
 			return (MALLOC_ERROR);
 		else

--- a/source/backend/redirection/io_file.c
+++ b/source/backend/redirection/io_file.c
@@ -90,8 +90,7 @@ static bool	handle_red_in(int *read_fd, char *filename)
 	fd = open(filename, O_RDONLY);
 	if (fd < 0)
 	{
-		print_error("%s: %s: ", PROGRAM_NAME, filename);
-		perror("");
+		print_error("%s: %s: %s\n", PROGRAM_NAME, filename, strerror(errno));
 		return (false);
 	}
 	replace_fd(&fd, read_fd);
@@ -105,8 +104,7 @@ static bool	handle_red_out(int *write_fd, char *filename, int o_flags)
 	fd = open(filename, o_flags, (S_IRUSR + S_IWUSR) | S_IRGRP | S_IROTH);
 	if (fd < 0)
 	{
-		print_error("%s: %s: ", PROGRAM_NAME, filename);
-		perror("");
+		print_error("%s: %s: %s\n", PROGRAM_NAME, filename, strerror(errno));
 		return (false);
 	}
 	replace_fd(&fd, write_fd);

--- a/source/backend/redirection/stdio_bind.c
+++ b/source/backend/redirection/stdio_bind.c
@@ -73,18 +73,18 @@ int	redirect_subshell_io(t_sh *shell, t_ct *cmd_table)
 
 bool	restore_std_io(int saved_std_io[2])
 {
-	bool	error;
+	int	error;
 
-	error = false;
+	error = SUCCESS;
 	if (saved_std_io[0] != -1)
 		if (dup2(saved_std_io[0], STDIN_FILENO) == -1)
-			error = true;
-	if (!error && saved_std_io[1] != -1)
+			error = errno;
+	if (saved_std_io[1] != -1)
 		if (dup2(saved_std_io[1], STDOUT_FILENO) == -1)
-			error = true;
-	if (error)
+			error = errno;
+	if (error != SUCCESS)
 	{
-		perror(PROGRAM_NAME);
+		print_error("%s: %s\n", PROGRAM_NAME, strerror(error));
 		return (false);
 	}
 	return (true);

--- a/source/backend/redirection/stdio_bind.c
+++ b/source/backend/redirection/stdio_bind.c
@@ -19,8 +19,7 @@ bool	save_std_io(int saved_std_io[2])
 	saved_std_io[1] = dup(STDOUT_FILENO);
 	if (saved_std_io[0] == -1 || saved_std_io[1] == -1)
 	{
-		print_error("%s: ", PROGRAM_NAME);
-		perror(NULL);
+		perror(PROGRAM_NAME);
 		safe_close(&saved_std_io[0]);
 		safe_close(&saved_std_io[1]);
 		return (false);
@@ -36,8 +35,7 @@ bool	redirect_scmd_io(t_sh *shell, int *read_fd, int *write_fd)
 	if (dup2(*read_fd, STDIN_FILENO) == -1 || \
 		dup2(*write_fd, STDOUT_FILENO) == -1)
 	{
-		print_error("%s: ", PROGRAM_NAME);
-		perror(NULL);
+		perror(PROGRAM_NAME);
 		ret = false;
 	}
 	if (shell->subshell_level != 0)
@@ -63,8 +61,7 @@ int	redirect_subshell_io(t_sh *shell, t_ct *cmd_table)
 		((read_fd != -1 && dup2(read_fd, STDIN_FILENO) == -1) || \
 		(write_fd != -1 && dup2(write_fd, STDOUT_FILENO) == -1)))
 	{
-		print_error("%s: ", PROGRAM_NAME);
-		perror(NULL);
+		perror(PROGRAM_NAME);
 		ret = GENERAL_ERROR;
 	}
 	safe_close(&read_fd);
@@ -85,8 +82,7 @@ bool	restore_std_io(int saved_std_io[2])
 			error = true;
 	if (error)
 	{
-		print_error("%s: ", PROGRAM_NAME);
-		perror(NULL);
+		perror(PROGRAM_NAME);
 		return (false);
 	}
 	return (true);

--- a/source/backend/redirection/stdio_bind.c
+++ b/source/backend/redirection/stdio_bind.c
@@ -16,12 +16,14 @@
 bool	save_std_io(int saved_std_io[2])
 {
 	saved_std_io[0] = dup(STDIN_FILENO);
-	saved_std_io[1] = dup(STDOUT_FILENO);
-	if (saved_std_io[0] == -1 || saved_std_io[1] == -1)
+	if (saved_std_io[0] != -1)
+		saved_std_io[1] = dup(STDOUT_FILENO);
+	else
+		saved_std_io[1] = -1;
+	if (saved_std_io[1] == -1)
 	{
 		perror(PROGRAM_NAME);
 		safe_close(&saved_std_io[0]);
-		safe_close(&saved_std_io[1]);
 		return (false);
 	}
 	return (true);


### PR DESCRIPTION
Standardize error message printing to always only use one function that prints the actual message.
- `print_error()` if more than just the program name should be in front of the error message.
- `perror()` if just the program name should be in front.