### PR TITLE
[CD] Allow .gitignore file and debug folder in evaluation branch

### DIFF
--- a/.github/actions/cleanup_full/action.yaml
+++ b/.github/actions/cleanup_full/action.yaml
@@ -9,5 +9,4 @@ runs:
           -type f ! -name '*.c' ! -name '*.h' ! -name '*.mk' ! -name 'Makefile' ! -name '.gitignore' \
           -exec rm -rf {} +
         find . -type d -empty -delete
-        rm -rf source/debug
       shell: bash

--- a/.github/actions/cleanup_full/action.yaml
+++ b/.github/actions/cleanup_full/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - run: |
         find . -type d -name .git -prune -o \
-          -type f ! -name '*.c' ! -name '*.h' ! -name '*.mk' ! -name 'Makefile' \
+          -type f ! -name '*.c' ! -name '*.h' ! -name '*.mk' ! -name 'Makefile' ! -name '.gitignore' \
           -exec rm -rf {} +
         find . -type d -empty -delete
         rm -rf source/debug

--- a/.github/actions/cleanup_partial/action.yaml
+++ b/.github/actions/cleanup_partial/action.yaml
@@ -9,5 +9,4 @@ runs:
           -type f ! -name '*.c' ! -name '*.h' ! -name '*.mk' ! -name 'Makefile' ! -name '.gitignore' \
           -exec rm -rf {} +
         find . -type d -empty -delete
-        rm -rf source/debug
       shell: bash

--- a/.github/actions/cleanup_partial/action.yaml
+++ b/.github/actions/cleanup_partial/action.yaml
@@ -6,7 +6,7 @@ runs:
   steps:
     - run: |
         find . -type d \( -name .git -o -name .github \) -prune -o \
-          -type f ! -name '*.c' ! -name '*.h' ! -name '*.mk' ! -name 'Makefile' \
+          -type f ! -name '*.c' ! -name '*.h' ! -name '*.mk' ! -name 'Makefile' ! -name '.gitignore' \
           -exec rm -rf {} +
         find . -type d -empty -delete
         rm -rf source/debug


### PR DESCRIPTION
I confirmed with Elidjah a while ago that it's allowed in the evaluation. It's allowed bc it's part of git. 
It's also useful during the evaluations to see more clearly what we edited during the eval.