### PR TITLE
[CHORE] Add back stdio.h for compatibility with some systems

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -20,6 +20,7 @@
 # include <linux/limits.h>
 # include <signal.h>
 # include <stdbool.h>
+# include <stdio.h>
 # include <stdlib.h>
 # include <unistd.h>
 # include <sysexits.h>


### PR DESCRIPTION
On some systems, readline needs the stdio.h header file to be included outside of it.