### PR TITLE
[REFACTOR] Exit for SIGPIPE signal without leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ https://starchart.cc/LeaYeh/minishell
 | Cross-end  | Signal      | Signal Handling        | Handled `ctrl-C` as `SIGINT` as bash behavior.                                                           | ✅      |
 |            |             |                        | Handled `ctrl-D` as `EOF` as bash behavior.                                                              | ✅      |
 |            |             |                        | Handled `ctrl-\\` as `SIGQUIT` as bash behavior.                                                         | ✅      |
-|            |             | Exception Handling     | Ignored `SIGPIPE` in internal process and set it back as default in external commands sub-process.       | ✅      |
+|            |             | Exception Handling     | Handled `SIGPIPE` in internal process and set it back as default in external commands sub-process.       | ✅      |
 |            |             |                        | Used `SIGUSR1` and `SIGTERM` to raise internal critical error to all related process and handle it depends on scenario.       | ✅      |
 
 
@@ -552,9 +552,8 @@ Reference: https://tldp.org/LDP/abs/html/internal.html
     - Before executing an external command (`handle_external_cmd`), we reset the signal handlers to their default settings (`SIG_DEFAULT`). This ensures that the external command can handle signals according to its own logic without interference from the shell's signal handling.
     - By resetting the signal handlers, we allow the external command to have complete control over how it handles signals, providing flexibility and adherence to Unix signal handling conventions.
 4. Handling SIGPIPE Signal for Builtin Commands:
-    - For builtin commands (`handle_builtin`), especially those involved in pipeline operations, we need to handle the `SIGPIPE` signal differently.
-    - We set up the signal handler to ignore (`SIG_IGNORE`) the `SIGPIPE` signal. This prevents the shell from terminating if a builtin command attempts to write to a broken pipeline, which is the default behavior. Instead, the shell continues execution as expected.
-    - Ignoring the `SIGPIPE` signal for builtin commands ensures seamless execution and prevents unintended termination due to broken pipes, which can occur during pipeline operations.
+    - For builtin commands (`handle_builtin`), especially those involved in pipeline operations, we decided to handle the `SIGPIPE` signal ourselves to stay consistent with the 42 practice of no resource _leaks_ at exit.
+    - We set up the signal handler to catch the `SIGPIPE` signal. This prevents the shell from terminating immediately if a builtin command attempts to write to a broken pipeline, which would be the default behavior of a `SIGPIPE` signal. Instead, the shell frees all its resources manually and then exits cleanly.
 
 #### Exception Handling
 

--- a/include/builtins.h
+++ b/include/builtins.h
@@ -16,10 +16,10 @@
 # include "defines.h"
 
 int			exec_env(char *env[]);
-int			exec_echo(char *args[]);
-int			exec_pwd(void);
-int			exec_cd(char *args[], t_list **env_list);
-int			exec_export(char *args[], t_list **env_list);
+int			exec_echo(t_sh *shell, char *args[]);
+int			exec_pwd(t_sh *shell);
+int			exec_cd(t_sh *shell, char *args[], t_list **env_list);
+int			exec_export(t_sh *shell, char *args[], t_list **env_list);
 int			exec_unset(char *args[], t_list **env_list);
 void		exec_exit(t_sh *shell, char *args[]);
 int			exec_easter_egg(void);

--- a/include/cd.h
+++ b/include/cd.h
@@ -46,6 +46,6 @@ char		*get_target_dir(char *args[], t_list *env_list);
 int			set_final_path(char **final_path, char **new_pwd, char *target_dir);
 
 /* update_pwd_env.c */
-bool		update_pwd_env(t_list **env_list, char *new_pwd);
+bool		update_pwd_env(t_list **env_list, char **new_pwd);
 
 #endif

--- a/include/defines.h
+++ b/include/defines.h
@@ -393,6 +393,7 @@ typedef struct s_shell
 	t_list			*token_list;
 	t_list_d		*cmd_table_list;
 	t_fct			*final_cmd_table;
+	void			*builtin_allocation;
 }	t_sh;
 
 #endif

--- a/include/export.h
+++ b/include/export.h
@@ -16,6 +16,6 @@
 # include "defines.h"
 
 /* print_exported_env.c */
-int		print_exported_env(t_list *env_list);
+int		print_exported_env(t_sh *shell, t_list *env_list);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -71,7 +71,7 @@ char		*get_value_from_env(char *env[], char *key);
 bool		is_key_in_env(char *env[], char *key);
 
 bool		append_env_node(
-				t_list **env_list, char *key, char *value, t_expt export);
+				t_list **env_list, char **key, char **value, t_expt export);
 void		free_env_node(t_env *env);
 bool		is_key_in_env_list(t_list *env_list, char *key);
 char		*get_value_from_env_list(t_list *env_list, char *key);
@@ -82,7 +82,7 @@ bool		process_str_to_env_list(
 				char *str, t_list **env_list, t_expt export);
 void		remove_env_node(t_list **env_list, char *key, char *value);
 bool		replace_env_value(
-				t_list *env_list, char *key, char *value, char **old_value);
+				t_list *env_list, char *key, char **value, char **old_value);
 
 /* Expansion utils */
 int			expand_list(

--- a/source/backend/builtins/cd/cd.c
+++ b/source/backend/builtins/cd/cd.c
@@ -33,7 +33,7 @@ int	exec_cd(t_sh *shell, char *args[], t_list **env_list)
 	free(final_path);
 	if (args[1] && ft_strcmp(args[1], "-") == 0)
 		ft_printf("%s\n", target_dir);
-	if (!update_pwd_env(env_list, shell->builtin_allocation))
+	if (!update_pwd_env(env_list, (char **)&shell->builtin_allocation))
 		return (ft_free_and_null(&shell->builtin_allocation), MALLOC_ERROR);
 	return (EXIT_SUCCESS);
 }

--- a/source/backend/builtins/cd/cd.c
+++ b/source/backend/builtins/cd/cd.c
@@ -14,26 +14,26 @@
 #include "clean.h"
 #include "utils.h"
 
-int	exec_cd(char *args[], t_list **env_list)
+int	exec_cd(t_sh *shell, char *args[], t_list **env_list)
 {
 	char	*final_path;
-	char	*new_pwd;
 	int		ret;
 	char	*target_dir;
 
 	target_dir = get_target_dir(args, *env_list);
 	if (!target_dir)
 		return (GENERAL_ERROR);
-	ret = set_final_path(&final_path, &new_pwd, target_dir);
+	ret = set_final_path(
+			&final_path, (char **)&shell->builtin_allocation, target_dir);
 	if (ret != SUCCESS)
 		return (ret);
 	if (chdir(final_path) == -1)
-		return (free(final_path), free(new_pwd),
+		return (free(final_path), ft_free_and_null(&shell->builtin_allocation),
 			handle_cd_error(errno, target_dir));
 	free(final_path);
 	if (args[1] && ft_strcmp(args[1], "-") == 0)
 		ft_printf("%s\n", target_dir);
-	if (!update_pwd_env(env_list, new_pwd))
-		return (free(new_pwd), MALLOC_ERROR);
+	if (!update_pwd_env(env_list, shell->builtin_allocation))
+		return (ft_free_and_null(&shell->builtin_allocation), MALLOC_ERROR);
 	return (EXIT_SUCCESS);
 }

--- a/source/backend/builtins/cd/env_pwd_update.c
+++ b/source/backend/builtins/cd/env_pwd_update.c
@@ -13,16 +13,16 @@
 #include "cd.h"
 #include "utils.h"
 
-static bool	handle_existing_pwd(t_list **env_list, char *prev_pwd);
-static bool	handle_non_existing_pwd(t_list **env_list, char *new_pwd);
+static bool	handle_existing_pwd(t_list **env_list, char **prev_pwd);
+static bool	handle_non_existing_pwd(t_list **env_list, char **new_pwd);
 
-bool	update_pwd_env(t_list **env_list, char *new_pwd)
+bool	update_pwd_env(t_list **env_list, char **new_pwd)
 {
 	char	*prev_pwd;
 
 	if (replace_env_value(*env_list, "PWD", new_pwd, &prev_pwd))
 	{
-		if (!handle_existing_pwd(env_list, prev_pwd))
+		if (!handle_existing_pwd(env_list, &prev_pwd))
 			return (free(prev_pwd), false);
 	}
 	else
@@ -31,7 +31,7 @@ bool	update_pwd_env(t_list **env_list, char *new_pwd)
 	return (true);
 }
 
-static bool	handle_existing_pwd(t_list **env_list, char *prev_pwd)
+static bool	handle_existing_pwd(t_list **env_list, char **prev_pwd)
 {
 	char	*key;
 	char	*prev_oldpwd;
@@ -43,20 +43,20 @@ static bool	handle_existing_pwd(t_list **env_list, char *prev_pwd)
 		key = ft_strdup("OLDPWD");
 		if (!key)
 			return (false);
-		if (!append_env_node(env_list, key, prev_pwd, EXPORT_NO))
+		if (!append_env_node(env_list, &key, prev_pwd, EXPORT_NO))
 			return (free(key), false);
 	}
 	return (true);
 }
 
-static bool	handle_non_existing_pwd(t_list **env_list, char *new_pwd)
+static bool	handle_non_existing_pwd(t_list **env_list, char **new_pwd)
 {
 	char	*key;
 
 	key = ft_strdup("PWD");
 	if (!key)
 		return (false);
-	if (!append_env_node(env_list, key, new_pwd, EXPORT_NO))
+	if (!append_env_node(env_list, &key, new_pwd, EXPORT_NO))
 		return (free(key), false);
 	remove_env_node(env_list, "OLDPWD", NULL);
 	return (true);

--- a/source/backend/builtins/echo.c
+++ b/source/backend/builtins/echo.c
@@ -16,22 +16,21 @@ static bool	is_newline_option(char *args[], int *i);
 static char	*combine_args(char *args[], bool end_with_newline);
 static int	get_combined_args_len(char *args[], bool end_with_newline);
 
-int	exec_echo(char *args[])
+int	exec_echo(t_sh *shell, char *args[])
 {
 	int		i;
 	bool	end_with_newline;
-	char	*combined_str;
 
 	i = 1;
 	if (is_newline_option(args, &i))
 		end_with_newline = false;
 	else
 		end_with_newline = true;
-	combined_str = combine_args(args + i, end_with_newline);
-	if (!combined_str)
+	shell->builtin_allocation = combine_args(args + i, end_with_newline);
+	if (!shell->builtin_allocation)
 		return (MALLOC_ERROR);
-	ft_printf("%s", combined_str);
-	free(combined_str);
+	ft_printf("%s", shell->builtin_allocation);
+	ft_free_and_null(&shell->builtin_allocation);
 	return (EXIT_SUCCESS);
 }
 

--- a/source/backend/builtins/export/export.c
+++ b/source/backend/builtins/export/export.c
@@ -16,13 +16,13 @@
 static bool	handle_var_export(char *str, t_list **env_list);
 static void	change_export_flag(t_list *env_list, char *key, t_expt export);
 
-int	exec_export(char *args[], t_list **env_list)
+int	exec_export(t_sh *shell, char *args[], t_list **env_list)
 {
 	int	i;
 	int	ret;
 
 	if (get_array_len(args) < 2)
-		return (print_exported_env(*env_list));
+		return (print_exported_env(shell, *env_list));
 	ret = SUCCESS;
 	i = 1;
 	while (args[i])

--- a/source/backend/builtins/export/export.c
+++ b/source/backend/builtins/export/export.c
@@ -51,7 +51,7 @@ static bool	handle_var_export(char *str, t_list **env_list)
 	{
 		if (!extract_env_value(&value, str))
 			return (free(key), false);
-		if (value && replace_env_value(*env_list, key, value, &old_value))
+		if (value && replace_env_value(*env_list, key, &value, &old_value))
 			free(old_value);
 		change_export_flag(*env_list, key, EXPORT_YES);
 		free(key);

--- a/source/backend/builtins/export/export_output.c
+++ b/source/backend/builtins/export/export_output.c
@@ -32,24 +32,24 @@ static t_env	*get_next_env_node(t_list *env_list, char *prev_key);
  * Malloc once, then use ft_snprintf to fill.
  * Then print once.
  */
-int	print_exported_env(t_list *env_list)
+int	print_exported_env(t_sh *shell, t_list *env_list)
 {
-	char	*export_printout;
-	int		format_len;
-	int		prefix_len;
-	int		total_len;
+	int	format_len;
+	int	prefix_len;
+	int	total_len;
 
 	prefix_len = ft_strlen(EXPORT_PREFIX);
 	format_len = ft_strlen("=\"\"\n");
 	total_len = get_total_export_printout_len(env_list, prefix_len, format_len);
 	if (total_len == 0)
 		return (SUCCESS);
-	export_printout = (char *)malloc(total_len + 1);
-	if (!export_printout)
+	shell->builtin_allocation = malloc(total_len + 1);
+	if (!shell->builtin_allocation)
 		return (MALLOC_ERROR);
-	fill_export_printout(env_list, export_printout, prefix_len, format_len);
-	ft_printf("%s", export_printout);
-	free(export_printout);
+	fill_export_printout(
+		env_list, shell->builtin_allocation, prefix_len, format_len);
+	ft_printf("%s", shell->builtin_allocation);
+	ft_free_and_null(&shell->builtin_allocation);
 	return (SUCCESS);
 }
 

--- a/source/backend/builtins/pwd.c
+++ b/source/backend/builtins/pwd.c
@@ -12,12 +12,10 @@
 
 #include "utils.h"
 
-int	exec_pwd(void)
+int	exec_pwd(t_sh *shell)
 {
-	char	*pwd;
-
-	pwd = getcwd(NULL, 0);
-	if (!pwd)
+	shell->builtin_allocation = getcwd(NULL, 0);
+	if (!shell->builtin_allocation)
 	{
 		print_error("%s: %s: ", PROGRAM_NAME, "pwd");
 		perror(NULL);
@@ -26,7 +24,7 @@ int	exec_pwd(void)
 		else
 			return (GENERAL_ERROR);
 	}
-	ft_printf("%s\n", pwd);
-	free(pwd);
+	ft_printf("%s\n", shell->builtin_allocation);
+	ft_free_and_null(&shell->builtin_allocation);
 	return (EXIT_SUCCESS);
 }

--- a/source/backend/executor/builtin_cmd.c
+++ b/source/backend/executor/builtin_cmd.c
@@ -87,7 +87,6 @@ static void	exec_builtin_cmd(t_sh *shell)
 {
 	t_fct	*final_cmd_table;
 
-	setup_signal(SIGPIPE, SIG_IGNORE);
 	final_cmd_table = shell->final_cmd_table;
 	if (ft_strcmp(final_cmd_table->simple_cmd[0], "env") == 0)
 		shell->exit_code = exec_env(final_cmd_table->env);
@@ -95,19 +94,18 @@ static void	exec_builtin_cmd(t_sh *shell)
 		shell->exit_code = exec_unset(final_cmd_table->simple_cmd,
 				&shell->env_list);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "echo") == 0)
-		shell->exit_code = exec_echo(final_cmd_table->simple_cmd);
+		shell->exit_code = exec_echo(shell, final_cmd_table->simple_cmd);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "pwd") == 0)
-		shell->exit_code = exec_pwd();
+		shell->exit_code = exec_pwd(shell);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "cd") == 0)
-		shell->exit_code = exec_cd(final_cmd_table->simple_cmd,
-				&shell->env_list);
+		shell->exit_code = exec_cd(shell,
+				final_cmd_table->simple_cmd, &shell->env_list);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "export") == 0)
-		shell->exit_code = exec_export(final_cmd_table->simple_cmd,
-				&shell->env_list);
+		shell->exit_code = exec_export(shell,
+				final_cmd_table->simple_cmd, &shell->env_list);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "exit") == 0)
 		exec_exit(shell, final_cmd_table->simple_cmd);
 	else if (ft_strcmp(final_cmd_table->simple_cmd[0], "~") == 0 && \
 			shell->is_interactive)
 		shell->exit_code = exec_easter_egg();
-	setup_signal(SIGPIPE, SIG_STANDARD);
 }

--- a/source/backend/executor/external_cmd.c
+++ b/source/backend/executor/external_cmd.c
@@ -64,6 +64,7 @@ static void	reset_external_signal_handler(void)
 	setup_signal(SIGTERM, SIG_DEFAULT);
 	setup_signal(SIGUSR1, SIG_DEFAULT);
 	setup_signal(SIGQUIT, SIG_DEFAULT);
+	setup_signal(SIGPIPE, SIG_DEFAULT);
 }
 
 static void	handle_exec_error(t_sh *shell, char *exec_path)

--- a/source/shell/clean.c
+++ b/source/shell/clean.c
@@ -52,6 +52,7 @@ static void	clean_shell(t_sh *shell)
 		ft_lstiter_d(shell->cmd_table_list, (void *)remove_heredoc_files);
 	ft_lstclear_d(&shell->cmd_table_list, (void *)free_cmd_table);
 	free_final_cmd_table(&shell->final_cmd_table);
+	ft_free_and_null(&shell->builtin_allocation);
 	rl_clear_history();
 }
 

--- a/source/shell/default_env_list.c
+++ b/source/shell/default_env_list.c
@@ -40,7 +40,7 @@ static bool	add_default_oldpwd_env_node(t_list **env_list)
 	if (!key)
 		return (false);
 	value = NULL;
-	if (!append_env_node(env_list, key, value, EXPORT_YES))
+	if (!append_env_node(env_list, &key, &value, EXPORT_YES))
 		return (free(key), false);
 	return (true);
 }
@@ -56,7 +56,7 @@ static bool	add_default_pwd_env_node(t_list **env_list)
 	value = getcwd(NULL, 0);
 	if (!value)
 		return (free(key), false);
-	if (!append_env_node(env_list, key, value, EXPORT_YES))
+	if (!append_env_node(env_list, &key, &value, EXPORT_YES))
 		return (free(key), free(value), false);
 	return (true);
 }

--- a/source/shell/init.c
+++ b/source/shell/init.c
@@ -32,5 +32,6 @@ bool	init_shell(t_sh *shell)
 	setup_signal(SIGTERM, SIG_STANDARD);
 	setup_signal(SIGUSR1, SIG_STANDARD);
 	setup_signal(SIGQUIT, SIG_IGNORE);
+	setup_signal(SIGPIPE, SIG_STANDARD);
 	return (true);
 }

--- a/source/shell/init.c
+++ b/source/shell/init.c
@@ -17,20 +17,13 @@
 
 bool	init_shell(t_sh *shell)
 {
+	ft_bzero(shell, sizeof(t_sh));
 	shell->is_interactive = isatty(STDIN_FILENO);
 	shell->pid = getpid_from_proc();
 	shell->subshell_pid = -1;
-	shell->subshell_level = 0;
-	shell->signal_record = 0;
 	init_pipe(&shell->old_pipe);
 	init_pipe(&shell->new_pipe);
 	shell->exit_code = EXIT_SUCCESS;
-	shell->child_pid_list = NULL;
-	shell->env_list = NULL;
-	shell->token_list = NULL;
-	shell->final_cmd_table = NULL;
-	shell->cmd_table_list = NULL;
-	shell->input_line = NULL;
 	if (!setup_env_list(shell))
 		return (false);
 	handle_signal_std(0, NULL, shell);

--- a/source/signal/signal_handler.c
+++ b/source/signal/signal_handler.c
@@ -51,8 +51,7 @@ void	handle_signal_std(int signo, siginfo_t *info, void *context)
 	else if (signo == SIGUSR1)
 	{
 		if (shell->subshell_level == 0)
-			clean_and_exit_shell(
-				shell, shell->exit_code, "Clean up and abort the program");
+			clean_and_exit_shell(shell, shell->exit_code, "Abort the shell");
 		else
 			clean_and_exit_shell(shell, shell->exit_code, NULL);
 	}

--- a/source/signal/signal_handler.c
+++ b/source/signal/signal_handler.c
@@ -56,7 +56,8 @@ void	handle_signal_std(int signo, siginfo_t *info, void *context)
 		else
 			clean_and_exit_shell(shell, shell->exit_code, NULL);
 	}
-	else if (signo == SIGTERM && shell->subshell_level != 0)
+	else if ((signo == SIGTERM && shell->subshell_level != 0) || \
+		signo == SIGPIPE)
 		clean_and_exit_shell(shell, shell->exit_code, NULL);
 }
 

--- a/source/signal/signal_handler.c
+++ b/source/signal/signal_handler.c
@@ -18,15 +18,22 @@ void	setup_signal(int signo, t_sig state)
 	struct sigaction	sa;
 
 	sigemptyset(&sa.sa_mask);
-	sa.sa_flags = SA_RESTART | SA_SIGINFO;
-	if (state == SIG_DEFAULT)
-		sa.sa_handler = SIG_DFL;
-	else if (state == SIG_IGNORE)
-		sa.sa_handler = SIG_IGN;
-	else if (state == SIG_STANDARD)
-		sa.sa_sigaction = handle_signal_std;
-	else if (state == SIG_RECORD)
-		sa.sa_sigaction = handle_signal_record;
+	if (state == SIG_DEFAULT || state == SIG_IGNORE)
+	{
+		sa.sa_flags = SA_RESTART;
+		if (state == SIG_DEFAULT)
+			sa.sa_handler = SIG_DFL;
+		else if (state == SIG_IGNORE)
+			sa.sa_handler = SIG_IGN;
+	}
+	else
+	{
+		sa.sa_flags = SA_RESTART | SA_SIGINFO;
+		if (state == SIG_STANDARD)
+			sa.sa_sigaction = handle_signal_std;
+		else if (state == SIG_RECORD)
+			sa.sa_sigaction = handle_signal_record;
+	}
 	if (sigaction(signo, &sa, NULL) != 0)
 		perror("The signal is not supported");
 }

--- a/source/utils/env_list_operation_utils.c
+++ b/source/utils/env_list_operation_utils.c
@@ -14,18 +14,20 @@
 #include "clean.h"
 
 bool	append_env_node(
-			t_list **env_list, char *key, char *value, t_expt export)
+			t_list **env_list, char **key, char **value, t_expt export)
 {
 	t_env	*env_node;
 
 	env_node = (t_env *)malloc(sizeof(t_env));
 	if (!env_node)
 		return (false);
-	env_node->key = key;
-	env_node->value = value;
+	env_node->key = *key;
+	env_node->value = *value;
 	env_node->export = export;
 	if (!ft_lstnew_back(env_list, env_node))
 		return (free(env_node), false);
+	*key = NULL;
+	*value = NULL;
 	return (true);
 }
 
@@ -48,7 +50,7 @@ bool	process_str_to_env_list(
 		return (false);
 	if (!extract_env_value(&value, str))
 		return (free(key), false);
-	if (!append_env_node(env_list, key, value, export))
+	if (!append_env_node(env_list, &key, &value, export))
 		return (free(key), free(value), false);
 	return (true);
 }
@@ -70,7 +72,7 @@ void	remove_env_node(t_list **env_list, char *key, char *value)
 }
 
 bool	replace_env_value(
-			t_list *env_list, char *key, char *value, char **old_value)
+			t_list *env_list, char *key, char **value, char **old_value)
 {
 	t_env	*env_node;
 
@@ -78,6 +80,7 @@ bool	replace_env_value(
 	if (!env_node)
 		return (*old_value = NULL, false);
 	*old_value = env_node->value;
-	env_node->value = value;
+	env_node->value = *value;
+	*value = NULL;
 	return (true);
 }


### PR DESCRIPTION
By setting up a signal handler that cleans and exits for SIGPIPE, we exit with the first `write()` to a broken pipe without trying over and over again.
To avoid memory leaks, allocations in builtins that have not been freed before a call to `write()` have to be safed into the `shell` struct so that they can be freed in the signal handler.

---

Also:
- Use `ft_bzero()` to init shell struct to 0.
- Shorten abort message.
- Make environment list operation functions more memory save.
- Fix `sa.sa_flags` not matching with the function pointers.