### PR TITLE
[FIX] Prevent infinite input loop when testing with readline in non-interactive mode

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -115,6 +115,9 @@
 # define PT_ROW_NUM			192
 # define UNDEFINED_STATE	-1
 
+/* User Input */
+# define MAX_INPUT_RETRIES	5
+
 /* Export */
 # define EXPORT_PREFIX		"export "
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -18,9 +18,9 @@
 /* User input utils */
 bool		read_input(
 				char **line,
+				t_sh *shell,
 				char *prompt,
-				bool add_to_history,
-				bool is_interactive);
+				bool add_to_history);
 
 /* Token list utils */
 t_tok		*init_token(t_tok_typ type, char *data);

--- a/source/backend/redirection/heredoc.c
+++ b/source/backend/redirection/heredoc.c
@@ -109,7 +109,7 @@ static t_hd_st	read_heredoc(t_sh *shell, t_list **line_list, char *here_end)
 	while (true)
 	{
 		line = NULL;
-		if (!read_input(&line, HEREDOC_PROMPT, false, shell->is_interactive))
+		if (!read_input(&line, shell, HEREDOC_PROMPT, false))
 			return (free(line), HD_ERROR);
 		if (shell->exit_code == TERM_BY_SIGNAL + SIGINT)
 			return (free(line), HD_ABORT);

--- a/source/main.c
+++ b/source/main.c
@@ -28,7 +28,7 @@ int	main(void)
 	print_welcome_msg(&shell);
 	while (true)
 	{
-		if (!read_input(&shell.input_line, PROMPT, true, shell.is_interactive))
+		if (!read_input(&shell.input_line, &shell, PROMPT, true))
 			continue ;
 		if (!shell.input_line)
 			exec_exit(&shell, NULL);

--- a/source/shell/clean.c
+++ b/source/shell/clean.c
@@ -21,7 +21,7 @@ static void	close_std_io(void);
 void	clean_and_exit_shell(t_sh *shell, int exit_code, char *msg)
 {
 	if (msg)
-		print_error("%s\n", msg);
+		print_error("%s: %s\n", PROGRAM_NAME, msg);
 	clean_shell(shell);
 	safe_close_all_pipes(shell);
 	free_get_next_line();

--- a/source/utils/user_input_utils.c
+++ b/source/utils/user_input_utils.c
@@ -34,7 +34,7 @@ bool	read_input(
 			free(tmp);
 		}
 	}
-	if (errno == EINTR)
+	if (errno == EINTR || errno == ENOTTY)
 		errno = SUCCESS;
 	else if (errno != SUCCESS)
 		return (false);

--- a/source/utils/user_input_utils.c
+++ b/source/utils/user_input_utils.c
@@ -38,7 +38,7 @@ bool	read_input(
 		errno = SUCCESS;
 	else if (errno != SUCCESS)
 		return (false);
-	if (add_to_history && *line && **line)
+	if (add_to_history && is_interactive && *line && **line)
 		add_history(*line);
 	return (errno == SUCCESS);
 }

--- a/source/utils/user_input_utils.c
+++ b/source/utils/user_input_utils.c
@@ -55,7 +55,7 @@ static bool	limit_retries(t_sh *shell, bool success)
 		retries = 0;
 		return (true);
 	}
-	else if (++retries > 5)
+	else if (++retries > MAX_INPUT_RETRIES)
 		clean_and_exit_shell(shell, GENERAL_ERROR, "read input failed");
 	print_error("%s: read input failed, trying again...\n", PROGRAM_NAME);
 	return (false);

--- a/source/utils/user_input_utils.c
+++ b/source/utils/user_input_utils.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "clean.h"
+#include "utils.h"
 
 static bool	limit_retries(t_sh *shell, bool success);
 
@@ -56,5 +57,6 @@ static bool	limit_retries(t_sh *shell, bool success)
 	}
 	else if (++retries > 5)
 		clean_and_exit_shell(shell, GENERAL_ERROR, "read input failed");
+	print_error("%s: read input failed, trying again...\n", PROGRAM_NAME);
 	return (false);
 }


### PR DESCRIPTION
**It would look like this:**
![Screenshot from 2024-07-24 13-53-16](https://github.com/user-attachments/assets/cac26d09-5b03-453d-8708-b2d0485b8d22)
