### PR TITLE
[BUILD] Use make's linker flags for libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/12/23 03:22:46 by ldulling          #+#    #+#              #
-#    Updated: 2024/07/02 17:06:11 by ldulling         ###   ########.fr        #
+#    Updated: 2024/07/31 02:14:58 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -49,9 +49,8 @@ CFLAGS_SAN		:=	-fsanitize=address,undefined,bounds,float-divide-by-zero
 CFLAGS_OPT		:=	-O3
 CFLAGS 			?=	$(CFLAGS_STD) $(CFLAGS_DBG)
 INCFLAGS 		:=	$(addprefix -I,$(INC_DIR) $(LIB_INCLUDES))
-LIBFLAGS		:=	$(addprefix -L,$(LIBRARIES)) \
-					$(addprefix -l,$(patsubst lib%,%,$(notdir \
-					$(LIBRARIES) $(LIBRARIES_EXT))))
+LDFLAGS			:=	$(addprefix -L,$(LIBRARIES))
+LDLIBS			:=	$(addprefix -l,$(patsubst lib%,%,$(notdir $(LIBRARIES) $(LIBRARIES_EXT))))
 MAKEFLAGS		:=	-j -s
 
 
@@ -272,7 +271,7 @@ waitforlib		:	lib
 #	Executable linking
 
 $(NAME)			:	$(LIBRARIES) $(OBJ)
-					$(CC) $(CFLAGS) $(INCFLAGS) $(OBJ) $(LIBFLAGS) -o $(NAME)
+					$(CC) $(CFLAGS) $(LDFLAGS) $(OBJ) $(LDLIBS) -o $(NAME)
 
 
 #	Source file compiling


### PR DESCRIPTION
[![image](https://github.com/user-attachments/assets/1015c9c0-16b0-4822-983d-55e07ad86d43)](https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#:~:text=SCCS%20get%20program.-,LDFLAGS,-%C2%B6)

I also finally understand why the order of the linker flags matters!
**First the flags, then the source files which need the libraries, then the libraries.**
This is because the linker looks for the symbols missing in a given file only in the files coming after it.

The location of where to look for the libraries (`-L` / `LDFLAGS`) is a flag for the linker, so it should be in front.
And the actual libraries to include (`-l` / `LDLIBS`) need to be after the object files.
That's why it makes sense that `LDFLAGS` and `LDLIBS` are separate variables.