### PR TITLE
[CI] Reduce timeouts in GH Actions

### DIFF
--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -31,7 +31,7 @@ jobs:
   regression_test:
     name: ${{ inputs.test_name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     outputs:
       source_failed_count: ${{ env.SOURCE_FAILED_COUNT }}
       target_failed_count: ${{ env.TARGET_FAILED_COUNT }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,7 @@ jobs:
     name: Memory Leak Test
     needs: prepare_test_matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Bernhard and Istvan already ran out of GH Action minutes because one of the test cases caused an infinite loop.
Since the tests are so heavily parallelized, each of the runners ran into the timeout and cost minutes.