### PR TITLE
[DOCS] Improve valgrind command to display exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,10 @@ export IGNORED_PATHS="/bin/* /usr/bin/* /usr/sbin/* $(which -a norminette)"
 export VALGRINDFLAGS+=" --trace-children-skip=$(echo $IGNORED_PATHS | sed '"'"'s/ /,/g'"'"')"
 export PATH="/bin:/usr/bin:/usr/sbin:$PATH"
 $VALGRIND $VALGRINDFLAGS $VALGRINDFDFLAGS ./minishell
+EXIT_CODE=$?
 rm -f $SUPPRESSION_FILE
+echo "Exit code: $EXIT_CODE"
+exit $EXIT_CODE
 '
 ```
 


### PR DESCRIPTION
Before, checking `echo $?` after the command would always return 0 bc the last command run was `rm -f`.
Now, the command prints the exit code as well as exits with the exit code of minishell.

I did this after Vikas told me he found it confusing why the exit code was always 0 with this command.