### PR TITLE
[CI] Fix clang-12 install issue with newest Ubuntu 24.04 image

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,6 +14,7 @@ runs:
   using: composite
   steps:
     - run: |
+        echo "deb http://archive.ubuntu.com/ubuntu/ jammy main universe" | sudo tee /etc/apt/sources.list.d/jammy-repositories.list
         sudo apt-get update
         sudo apt-get install -y build-essential clang-12=1:12.0.1-19ubuntu3 valgrind
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,6 +14,9 @@ runs:
   using: composite
   steps:
     - run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 12
         sudo apt-get update
         sudo apt-get install -y build-essential clang-12 valgrind
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,9 +14,13 @@ runs:
   using: composite
   steps:
     - run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential valgrind libreadline-dev
+      shell: bash
+    - run: |
         echo "deb http://archive.ubuntu.com/ubuntu/ jammy main universe" | sudo tee /etc/apt/sources.list.d/jammy-repositories.list
         sudo apt-get update
-        sudo apt-get install -y build-essential clang-12=1:12.0.1-19ubuntu3 valgrind libreadline-dev
+        sudo apt-get install -y clang-12=1:12.0.1-19ubuntu3
       shell: bash
     - run: |
         echo "Iy" | bash -c 'bash <(curl -s https://raw.githubusercontent.com/tmatis/funcheck/main/scripts/install.sh)'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -16,7 +16,7 @@ runs:
     - run: |
         echo "deb http://archive.ubuntu.com/ubuntu/ jammy main universe" | sudo tee /etc/apt/sources.list.d/jammy-repositories.list
         sudo apt-get update
-        sudo apt-get install -y build-essential clang-12=1:12.0.1-19ubuntu3 valgrind
+        sudo apt-get install -y build-essential clang-12=1:12.0.1-19ubuntu3 valgrind libreadline-dev
       shell: bash
     - run: |
         echo "Iy" | bash -c 'bash <(curl -s https://raw.githubusercontent.com/tmatis/funcheck/main/scripts/install.sh)'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -14,11 +14,8 @@ runs:
   using: composite
   steps:
     - run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 12
         sudo apt-get update
-        sudo apt-get install -y build-essential clang-12 valgrind
+        sudo apt-get install -y build-essential clang-12=1:12.0.1-19ubuntu3 valgrind
       shell: bash
     - run: |
         echo "Iy" | bash -c 'bash <(curl -s https://raw.githubusercontent.com/tmatis/funcheck/main/scripts/install.sh)'


### PR DESCRIPTION
GitHub updated the default image of `ubuntu-latest` to 24.04 from 22.04.
In that image clang-12 and libreadline-dev were missing.