### PR TITLE
[FIX] Fix newline after program with exit code 130

### DIFF
--- a/.github/workflows/test_image.yaml
+++ b/.github/workflows/test_image.yaml
@@ -17,5 +17,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up test environment
         uses: ./.github/actions/setup
+        with:
+          tester_dir: ${{ env.TESTER_DIR }}
+          scripts_dir: ${{ env.SCRIPTS_DIR }}
       - name: Set up tmate session
         uses: mxschmitt/action-tmate@v3

--- a/include/defines.h
+++ b/include/defines.h
@@ -13,7 +13,9 @@
 #ifndef DEFINES_H
 # define DEFINES_H
 
-# define _DEFAULT_SOURCE
+# ifndef _DEFAULT_SOURCE
+#  define _DEFAULT_SOURCE
+# endif
 
 # include <dirent.h>
 # include <errno.h>

--- a/source/backend/executor/control_operator.c
+++ b/source/backend/executor/control_operator.c
@@ -47,8 +47,6 @@ static bool	should_execute_next_pipeline(t_sh *shell, t_ct_typ type)
 		shell->exit_code = TERM_BY_SIGNAL + shell->signal_record;
 		return (false);
 	}
-	if (shell->exit_code == TERM_BY_SIGNAL + SIGINT)
-		return (false);
 	if (type == C_AND && shell->exit_code == 0)
 		return (true);
 	else if (type == C_OR && shell->exit_code != 0)

--- a/source/backend/executor/wait_process.c
+++ b/source/backend/executor/wait_process.c
@@ -45,7 +45,7 @@ void	wait_all_child_pid(t_sh *shell)
 		child_pid_node = child_pid_node->next;
 	}
 	if (got_sigint)
-		ft_printf("\n");
+		print_error("\n");
 	shell->exit_code = handle_exit_status(exit_wstatus);
 }
 


### PR DESCRIPTION
- Fixes programs with exit code 130 causing a newline.
- Fixes minishell running in minishell printing too many newlines after SIGINT + exit.
- Fixes nested subshells printing too many newlines: `( ( (cat) ) )`
- Fixes `cat | ./segfault` behavior: `Segmentation fault` only gets printed at end of pipeline.
- This also fixes the exit code affecting `&&`/`|| `: `./return_130 || echo 123` did not print `123`.

- Resolves #257

---

### Known issues

- `(sleep 3 && ./segfault)` should not print `Segmentation fault` (which is super weird bc `(./segfault)` **does** print `Segmentation fault`!
- SIGQUIT behavior in subshells remains unsolved - #206