### PR TITLE
[CI] Fix test case printout

### DIFF
--- a/.github/scripts/print_test_case.sh
+++ b/.github/scripts/print_test_case.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 test_number=$(echo "$LINE" | grep -oP '\d+(?=:)' | head -1 || true)
-line_number=$(echo "$LINE" | grep -oP '\d+' | tail -1 || true)
+line_number=$(echo "$LINE" | grep -oP '(?<=:)\d+' | tail -1 || true)
 file_path=$(echo "$LINE" | grep -oP '\s*'"$TESTER_DIR"'/cmds/.*\.sh' || true)
 file_basename=$(basename "${file_path%.*}")
 file_dirname=$(basename "$(dirname "$file_path")")


### PR DESCRIPTION
The issue was caused by a change to the tester.
The tester now uses `\033[0m` instead of `\033[m` to reset the colors. 
I need to get the line number to print the test case, and the script detected the line number to be purely the last number, which now was always 0. 
When passing 0 to another `sed` call this error happens.

![image](https://github.com/user-attachments/assets/4bfd9231-3d5c-49e6-95f7-3443230e6a65)