### PR TITLE
[BUILD] Makefile compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/12/23 03:22:46 by ldulling          #+#    #+#              #
-#    Updated: 2024/09/05 10:57:10 by ldulling         ###   ########.fr        #
+#    Updated: 2025/01/24 23:34:49 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -127,6 +127,8 @@ DEP_SUBDIRS		:=	$(sort $(dir $(DEP)))
 
 export				CC CFLAGS MAKECMDGOALS MAKEFLAGS
 
+SHELL			:=	/bin/bash
+
 PHONY_TARGETS	:=	all run noenv nocolor opt san val valfd term clear modes re \
 					build lib waitforlib clean fclean ffclean
 ENV_VARIABLES	:=	MODE
@@ -200,19 +202,19 @@ endif
 
 all				:
 					if $(MAKE) --question build; then \
-						echo -n $(MSG_NO_CHANGE); \
-						echo -n $(MSG_HELP); \
+						echo -e -n $(MSG_NO_CHANGE); \
+						echo -e -n $(MSG_HELP); \
 					else \
-						echo -n $(MSG_MODE); \
-						echo -n " "$(MSG_INFO); \
-						echo -n " "$(MSG_HELP); \
-						echo -n $(MSG_START); \
+						echo -e -n $(MSG_MODE); \
+						echo -e -n " "$(MSG_INFO); \
+						echo -e -n " "$(MSG_HELP); \
+						echo -e -n $(MSG_START); \
 						if $(MAKE) build; then \
 							echo; \
-							echo -n $(MSG_SUCCESS); \
+							echo -e -n $(MSG_SUCCESS); \
 						else \
 							echo; \
-							echo -n $(MSG_FAILURE); \
+							echo -e -n $(MSG_FAILURE); \
 							exit 42; \
 						fi; \
 					fi
@@ -282,7 +284,7 @@ $(NAME)			:	$(LIBRARIES) $(OBJ)
 
 $(OBJ_DIR)/%.o	:	$(SRC_DIR)/%$(SRC_EXTENSION) $(BUILDFILES) | $(OBJ_SUBDIRS)
 					$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@ \
-						&& echo -n $(MSG_PROGRESS)
+						&& echo -e -n $(MSG_PROGRESS)
 
 
 #	Pre-processing and dependency file creation
@@ -301,7 +303,7 @@ $(DEP_SUBDIRS)	:
 # ***************************** CLEAN TARGETS ******************************** #
 
 clean			:
-					echo -n $(MSG_CLEAN)
+					echo -e -n $(MSG_CLEAN)
 					$(MAKE) clean -C $(LIBRARIES)
 					rm -f $(OBJ) $(DEP)
                     ifneq (, $(wildcard $(OBJ_DIR)))
@@ -310,120 +312,120 @@ clean			:
                     ifneq (, $(wildcard $(DEP_DIR)))
 						-find $(DEP_DIR) -type d -empty -delete
                     endif
-					echo -n $(MSG_SUCCESS)
+					echo -e -n $(MSG_SUCCESS)
 
 fclean			:
-					echo -n $(MSG_FCLEAN)
+					echo -e -n $(MSG_FCLEAN)
 					$(MAKE) clean
 					$(MAKE) fclean -C $(LIBRARIES)
 					rm -f $(NAME)
-					echo -n $(MSG_SUCCESS)
+					echo -e -n $(MSG_SUCCESS)
 
 ffclean			:
-					echo -n $(MSG_FFCLEAN)
+					echo -e -n $(MSG_FFCLEAN)
 					$(MAKE) fclean
 					rm -rf $(OBJ_DIR) $(DEP_DIR)
-					echo -n $(MSG_SUCCESS)
+					echo -e -n $(MSG_SUCCESS)
 
 
 # ****************************** HELP TARGETS ******************************** #
 
 help			:
-					echo "Targets:"
-					echo "  all              Build the project (default target)"
-					echo "  run              Build and run the project"
-					echo "  noenv            Build and run the project with an empty environment"
-					echo "  nocolor          Rebuild the project without colors in the prompt and printouts"
-					echo "  opt              Rebuild the project with optimizations"
-					echo "  san              Rebuild the project with sanitizers"
-					echo "  val              Build and run the project with valgrind"
-					echo "  valfd            Build and run the project with valgrind and file descriptor tracking"
-					echo "  term             Build and run the project in a new terminal window"
-					echo "  clear            Build the project and clear the terminal"
-					echo "  re               Rebuild the project"
-					echo "  clean            Remove build artifacts"
-					echo "  fclean           Remove build artifacts and executable"
-					echo "  ffclean          Remove build artifacts and executable without checking for unknown files"
-					echo "  print-%          Print the value of a Makefile variable (replace % with variable name)"
-					echo "  help             Display this message"
-					echo "  help-% | %-help  Display more information for a specific target (replace % with target name)"
+					echo -e "Targets:"
+					echo -e "  all              Build the project (default target)"
+					echo -e "  run              Build and run the project"
+					echo -e "  noenv            Build and run the project with an empty environment"
+					echo -e "  nocolor          Rebuild the project without colors in the prompt and printouts"
+					echo -e "  opt              Rebuild the project with optimizations"
+					echo -e "  san              Rebuild the project with sanitizers"
+					echo -e "  val              Build and run the project with valgrind"
+					echo -e "  valfd            Build and run the project with valgrind and file descriptor tracking"
+					echo -e "  term             Build and run the project in a new terminal window"
+					echo -e "  clear            Build the project and clear the terminal"
+					echo -e "  re               Rebuild the project"
+					echo -e "  clean            Remove build artifacts"
+					echo -e "  fclean           Remove build artifacts and executable"
+					echo -e "  ffclean          Remove build artifacts and executable without checking for unknown files"
+					echo -e "  print-%          Print the value of a Makefile variable (replace % with variable name)"
+					echo -e "  help             Display this message"
+					echo -e "  help-% | %-help  Display more information for a specific target (replace % with target name)"
 					echo
-					echo "Environment Variables:"
-					echo "  MODE             Build mode to combine multiple targets"
+					echo -e "Environment Variables:"
+					echo -e "  MODE             Build mode to combine multiple targets"
 					echo
-					echo "Usage: make [\\$(STY_UND)target\\$(STY_RES)] [MODE=\"<\\$(STY_UND)mode1\\$(STY_RES)> [\\$(STY_UND)mode2\\$(STY_RES)] [...]\"]"
+					echo -e "Usage: make [\\$(STY_UND)target\\$(STY_RES)] [MODE=\"<\\$(STY_UND)mode1\\$(STY_RES)> [\\$(STY_UND)mode2\\$(STY_RES)] [...]\"]"
 
 help-all		:
-					echo "Build the project."
-					echo "This is the default target when no target is specified."
+					echo -e "Build the project."
+					echo -e "This is the default target when no target is specified."
 
 help-run		:
-					echo "Build the project and run the executable."
+					echo -e "Build the project and run the executable."
 
 help-noenv		:
-					echo "Build the project and run executable with an empty environment (env -i)."
+					echo -e "Build the project and run executable with an empty environment (env -i)."
 
 help-nocolor	:
-					echo "Rebuild the project without colors in the prompt and printouts."
-					echo "Useful when ANSI escape sequences are not well supported in a terminal emulator."
+					echo -e "Rebuild the project without colors in the prompt and printouts."
+					echo -e "Useful when ANSI escape sequences are not well supported in a terminal emulator."
 
 help-opt		:
-					echo "Rebuild the project with the following compiler optimization flags:"
-					echo "  $(CFLAGS_OPT)"
+					echo -e "Rebuild the project with the following compiler optimization flags:"
+					echo -e "  $(CFLAGS_OPT)"
 
 help-san		:
-					echo "Rebuild the project with the following sanitizer flags:"
-					echo "  $(CFLAGS_SAN)"
+					echo -e "Rebuild the project with the following sanitizer flags:"
+					echo -e "  $(CFLAGS_SAN)"
 
 help-val		:
-					echo "Build the project and run the executable with valgrind."
+					echo -e "Build the project and run the executable with valgrind."
 					echo
-					echo "The following valgrind flags are used:"
-					echo "$(VALGRINDFLAGS)" | tr ' ' '\n' | sed 's/^/  /'
+					echo -e "The following valgrind flags are used:"
+					echo -e "$(VALGRINDFLAGS)" | tr ' ' '\n' | sed 's/^/  /'
 
 help-valfd		:
-					echo "Build the project and run the executable with valgrind and file descriptor tracking."
-					echo "A new terminal window is opened to avoid inheriting open file descriptors."
+					echo -e "Build the project and run the executable with valgrind and file descriptor tracking."
+					echo -e "A new terminal window is opened to avoid inheriting open file descriptors."
 					echo
-					echo "The following valgrind flags are used:"
-					echo "$(VALGRINDFLAGS)" | tr ' ' '\n' | sed 's/^/  /'
-					echo "File descriptor specific flags:"
-					echo "$(VALGRINDFDFLAGS)" | tr ' ' '\n' | sed 's/^/  /'
+					echo -e "The following valgrind flags are used:"
+					echo -e "$(VALGRINDFLAGS)" | tr ' ' '\n' | sed 's/^/  /'
+					echo -e "File descriptor specific flags:"
+					echo -e "$(VALGRINDFDFLAGS)" | tr ' ' '\n' | sed 's/^/  /'
 
 help-term		:
-					echo "Build the project and run the executable in a new terminal window."
+					echo -e "Build the project and run the executable in a new terminal window."
 
 help-clear		:
-					echo "Build the project and clear the terminal."
+					echo -e "Build the project and clear the terminal."
 
 help-re			:
-					echo "Rebuild the project."
+					echo -e "Rebuild the project."
 
 help-clean		:
-					echo "Remove build artifacts."
+					echo -e "Remove build artifacts."
 
 help-fclean		:
-					echo "Remove build artifacts and the executable."
+					echo -e "Remove build artifacts and the executable."
 
 help-ffclean	:
-					echo "Remove build artifacts and the executable without checking for unknown files."
+					echo -e "Remove build artifacts and the executable without checking for unknown files."
 
 help-print		:
-					echo "Print the value of a Makefile variable by appending the variable name to print-..."
-					echo "Useful for Makefile debugging."
+					echo -e "Print the value of a Makefile variable by appending the variable name to print-..."
+					echo -e "Useful for Makefile debugging."
 					echo
-					echo "Usage: make print-<\\$(STY_UND)variable name\\$(STY_RES)>"
+					echo -e "Usage: make print-<\\$(STY_UND)variable name\\$(STY_RES)>"
 
 help-help		:
-					echo "Display more information for a specific target by appending or prepending help."
+					echo -e "Display more information for a specific target by appending or prepending help."
 					echo
-					echo "Usage: make help-<\\$(STY_UND)target\\$(STY_RES)> | make <\\$(STY_UND)target\\$(STY_RES)>-help"
+					echo -e "Usage: make help-<\\$(STY_UND)target\\$(STY_RES)> | make <\\$(STY_UND)target\\$(STY_RES)>-help"
 
 help-MODE MODE-help:
-					echo "Build mode to combine with other targets."
-					echo "Multiple modes can be combined by separating them with a space."
+					echo -e "Build mode to combine with other targets."
+					echo -e "Multiple modes can be combined by separating them with a space."
 					echo
-					echo "Usage: make <\\$(STY_UND)target\\$(STY_RES)> MODE=\"<\\$(STY_UND)mode1\\$(STY_RES)> [\\$(STY_UND)mode2\\$(STY_RES)] [...]\""
+					echo -e "Usage: make <\\$(STY_UND)target\\$(STY_RES)> MODE=\"<\\$(STY_UND)mode1\\$(STY_RES)> [\\$(STY_UND)mode2\\$(STY_RES)] [...]\""
 
 %-help:
 					$(MAKE) help-$(subst -help,,$@)
@@ -547,7 +549,7 @@ endif
 # *************************** MAKEFILE DEBUGGING ***************************** #
 
 print-%			:
-					echo $* = $($*)
+					echo -e $* = $($*)
 
 
 # ********************************* NOTES ************************************ #

--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,14 @@ BUILDFILES		:=	Makefile \
 
 #	Flags
 
-CC 				?=	cc
+CC				?=	cc
 CC_VERSION		:=	$(shell $(CC) --version | head -1)
 CFLAGS_STD		:=	-Wall -Wextra -Werror
 CFLAGS_DBG		:=	-ggdb3
 CFLAGS_SAN		:=	-fsanitize=address,undefined,bounds,float-divide-by-zero
 CFLAGS_OPT		:=	-O3
-CFLAGS 			?=	$(CFLAGS_STD) $(CFLAGS_DBG)
-CPPFLAGS 		:=	$(addprefix -I,$(INC_DIR) $(LIB_INCLUDES))
+CFLAGS			?=	$(CFLAGS_STD) $(CFLAGS_DBG)
+CPPFLAGS		:=	$(addprefix -I,$(INC_DIR) $(LIB_INCLUDES))
 DEPFLAGS		=	-M -MP -MF $@ -MT "$(OBJ_DIR)/$*.o $@"
 LDFLAGS			:=	$(addprefix -L,$(LIBRARIES))
 LDLIBS			:=	$(addprefix -l,$(patsubst lib%,%,$(notdir $(LIBRARIES) $(LIBRARIES_EXT))))
@@ -105,14 +105,14 @@ else
 TERMINALTITLE	:=	$(MAKE_NAME)
 endif
 
-TERMINALFLAGS	:=	--title="$(TERMINALTITLE)" -- /bin/sh -c
+TERMINALFLAGS	:=	--title="$(TERMINALTITLE)" --
 
 
 #	Files
 
 include				$(BUILD_DIR)/source_files.mk
 SRC_EXTENSION	:=	.c
-OBJ 			:=	$(SRC:%$(SRC_EXTENSION)=$(OBJ_DIR)/%.o)
+OBJ				:=	$(SRC:%$(SRC_EXTENSION)=$(OBJ_DIR)/%.o)
 DEP				:=	$(SRC:%$(SRC_EXTENSION)=$(DEP_DIR)/%.d)
 
 
@@ -231,10 +231,10 @@ modes			:
 						clear; \
 					fi
 					if [ "$(NEW_TERM)" = "true" ] && [ -n "$(TERMINAL)" ]; then \
-						$(TERMINAL) $(TERMINALFLAGS) \
-							"bash --posix -c 'trap \"\" SIGINT; \
+						$(TERMINAL) $(TERMINALFLAGS) bash --posix -c \
+							"trap '' SIGINT; \
 							$(ENV) ./$(NAME); \
-							exec bash --posix'"; \
+							exec bash --posix"; \
 					elif [ "$(RUN)" = "true" ]; then \
 						$(ENV) "./$(NAME)"; \
 					fi
@@ -276,7 +276,7 @@ waitforlib		:	lib
 #	Executable linkage
 
 $(NAME)			:	$(LIBRARIES) $(OBJ)
-					$(CC) $(CFLAGS) $(LDFLAGS) $(OBJ) $(LDLIBS) -o $@
+					$(CC) $(CFLAGS) $(LDFLAGS) $(OBJ) $(LDLIBS) -o $(NAME)
 
 
 #	Source file compilation

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,6 @@ VALGRIND		:=	$(shell which valgrind)
 
 VALGRINDFLAGS	=	--errors-for-leak-kinds=all \
 					--leak-check=full \
-					--read-var-info=yes \
 					--show-error-list=yes \
 					--show-leak-kinds=all \
 					--suppressions=$(CURDIR)/minishell.supp \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: ldulling <ldulling@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/12/23 03:22:46 by ldulling          #+#    #+#              #
-#    Updated: 2025/01/24 23:47:24 by ldulling         ###   ########.fr        #
+#    Updated: 2025/01/24 23:53:02 by ldulling         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -438,7 +438,7 @@ help-MODE MODE-help:
 help-TERMINAL TERMINAL-help:
 					echo -e "Override the default terminal emulator for targets opening a new terminal window."
 					echo
-					echo -e "Usage: make <target> TERMINAL=<\\$(STY_UND)terminal\\$(STY_RES)>"
+					echo -e "Usage: make <\\$(STY_UND)target\\$(STY_RES)> TERMINAL=<\\$(STY_UND)terminal\\$(STY_RES)>"
 
 %-help:
 					$(MAKE) help-$(subst -help,,$@)


### PR DESCRIPTION
- **Properly display escape sequence printouts on all systems**
  By default, Make uses `/bin/sh` and it does not interpret the escape sequences on all systems without the `-e` flag, but the `-e` flag is not supported on all systems with `sh`.
- **Remove unnecessary `--read-var-info=yes` valgrind flag**
  It slows down valgrind's startup time significantly and produces unsupported DWARF warnings on campus environment.
  Even if it would work, the information it produces is not really needed. Considering all this, it's understandable why it is under "Uncommon Options" in valgrind's manual.
- **Support multiple terminal emulators in `term` target**