### PR TITLE
[CI] Increase GitHub Actions timeouts

### DIFF
--- a/.github/workflows/regression_test.yaml
+++ b/.github/workflows/regression_test.yaml
@@ -34,7 +34,7 @@ jobs:
   regression_test:
     name: ${{ inputs.test_name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       source_failed_count: ${{ env.SOURCE_FAILED_COUNT }}
       target_failed_count: ${{ env.TARGET_FAILED_COUNT }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
   compilation_test:
     name: Compilation Test
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +59,7 @@ jobs:
     name: Memory Leak Test
     needs: prepare_test_matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +106,7 @@ jobs:
     name: Crash Test
     needs: compilation_test
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
For a while now jobs often fail because of timeout. It looks like the runners provided by GitHub are just slower now, and their new base images take longer to set up.